### PR TITLE
Search worker with dria-searching-agent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,9 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [features]
-default = ["synthesis"]
+default = ["search_python"]
 synthesis = []
+search_python = [] 
 
 # test features
 waku_test = []

--- a/compose.yml
+++ b/compose.yml
@@ -18,12 +18,15 @@ services:
   compute:
     build: "./"
     environment:
+      DKN_OLLAMA_HOST: "http://host.docker.internal"
+      DKN_OLLAMA_PORT: "11434"
+      DKN_OLLAMA_MODEL: ${DKN_OLLAMA_MODEL:-phi3}
       DKN_WAKU_URL: "http://host.docker.internal:8645"
       DKN_WALLET_SECRET_KEY: ${ETH_TESTNET_KEY}
       DKN_ADMIN_PUBLIC_KEY: "0208ef5e65a9c656a6f92fb2c770d5d5e2ecffe02a6aade19207f75110be6ae658"
+      RUST_LOG: "info"
       SEARCH_AGENT_URL: "http://search-agent:5000"
       SEARCH_AGENT_MANAGER: true
-      RUST_LOG: "debug"
     networks:
       - dkn-search-node-python-network
     depends_on:
@@ -142,7 +145,7 @@ services:
       OPENAI_MODEL_NAME: "gpt4"
       VISION_TOOL_MODEL: "CLAUDE_SONNET"
 
-      OLLAMA_URL: http://host.docker.internal:11434
+      OLLAMA_URL: http://host.docker.internal:11434 # duplicated with compute node
       QDRANT_URL: http://qdrant:6333
       BROWSERLESS_URL: http://browserless:3000
     networks:

--- a/compose.yml
+++ b/compose.yml
@@ -18,16 +18,16 @@ services:
   compute:
     build: "./"
     environment:
-      DKN_OLLAMA_HOST: "http://host.docker.internal"
-      DKN_OLLAMA_PORT: "11434"
-      DKN_OLLAMA_MODEL: ${DKN_OLLAMA_MODEL:-phi3}
       DKN_WAKU_URL: "http://host.docker.internal:8645"
       DKN_WALLET_SECRET_KEY: ${ETH_TESTNET_KEY}
       DKN_ADMIN_PUBLIC_KEY: "0208ef5e65a9c656a6f92fb2c770d5d5e2ecffe02a6aade19207f75110be6ae658"
-      RUST_LOG: "info"
-    network_mode: "host"
+      SEARCH_AGENT_URL: "http://search-agent:5000"
+      SEARCH_AGENT_MANAGER: true
+      RUST_LOG: "debug"
+    networks:
+      - dkn-search-node-python-network
     depends_on:
-      - nwaku
+      - search-agent
 
   # Waku Node
   nwaku:
@@ -57,7 +57,9 @@ services:
     entrypoint: sh
     command:
       - /opt/run_node.sh
-
+    networks:
+      - dkn-search-node-python-network
+    profiles: [waku]
 
   # Ollama Container (CPU)
   ollama:
@@ -65,7 +67,9 @@ services:
     ports:
       - 11434:11434
     volumes:
-      - ollama:/root/.ollama
+      - ollama:~/.ollama
+    networks:
+      - dkn-search-node-python-network
     profiles: [ollama-cpu]
 
   # Ollama Container (ROCM)
@@ -78,6 +82,8 @@ services:
     devices:
       - "/dev/kfd"
       - "/dev/dri"
+    networks:
+      - dkn-search-node-python-network
     profiles: [ollama-rocm]
 
   # Ollama Container (CUDA)
@@ -94,7 +100,66 @@ services:
             - driver: nvidia
               count: 1
               capabilities: [gpu]
+    networks:
+      - dkn-search-node-python-network
     profiles: [ollama-cuda]
+
+  # dria-search-agent profile
+  qdrant:
+    image: qdrant/qdrant
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - ./qdrant_storage:/qdrant/storage:z
+    networks:
+      - dkn-search-node-python-network
+    profiles: [search-python]
+
+  browserless:
+    image: ghcr.io/browserless/chromium
+    environment:
+      - TOKEN=6R0W53R135510
+    ports:
+      - "3030:3000"
+    networks:
+      - dkn-search-node-python-network
+    profiles: [search-python]
+
+  search-agent:
+    image: dria-searching-agent:server
+    ports:
+      - 5000:5000
+    environment:
+      AGENT_MODEL_PROVIDER: Ollama
+      AGENT_MODEL: phi3:latest
+      
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      SERPER_API_KEY: ${SERPER_API_KEY}
+      BROWSERLESS_TOKEN: ${BROWSERLESS_TOKEN}
+
+      OPENAI_MODEL_NAME: "gpt4"
+      VISION_TOOL_MODEL: "CLAUDE_SONNET"
+
+      OLLAMA_URL: http://host.docker.internal:11434
+      QDRANT_URL: http://qdrant:6333
+      BROWSERLESS_URL: http://browserless:3000
+    networks:
+      dkn-search-node-python-network:
+    profiles: [search-python]
+
+
+networks:
+  dkn-search-node-python-network:
+    name: dkn-search-node-python-network
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.30.0.0/24
+          gateway: 172.30.0.1
+
 
 volumes:
   ollama:

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -24,6 +24,9 @@ pub struct DriaComputeNodeConfig {
     pub DKN_WALLET_ADDRESS: [u8; 20],
     /// Admin public key, used for message authenticity.
     pub DKN_ADMIN_PUBLIC_KEY: PublicKey,
+    /// Dria-searching-agent
+    pub SEARCH_AGENT_URL: String,
+    pub SEARCH_AGENT_MANAGER: bool,
 }
 
 #[cfg(test)]
@@ -73,11 +76,20 @@ impl DriaComputeNodeConfig {
             hex::encode(admin_public_key.serialize_compressed())
         );
 
+        let agent_url = env::var("SEARCH_AGENT_URL").unwrap_or_default();
+        let agent_manager_enabled = match env::var("SEARCH_AGENT_MANAGER").unwrap_or_default().to_lowercase().as_str() {
+            "1" | "true" | "yes" => true,
+            _ => false,
+        };
+    
+
         Self {
             DKN_ADMIN_PUBLIC_KEY: admin_public_key,
             DKN_WALLET_SECRET_KEY: secret_key,
             DKN_WALLET_PUBLIC_KEY: public_key,
             DKN_WALLET_ADDRESS: address,
+            SEARCH_AGENT_URL:  agent_url,
+            SEARCH_AGENT_MANAGER:  agent_manager_enabled
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,18 @@ use tokio_util::task::TaskTracker;
 // diagnostic & heartbeat always enabled
 use dkn_compute::workers::diagnostic::*;
 use dkn_compute::workers::heartbeat::*;
+use std::process::exit;
 use std::sync::Arc;
+
+use dkn_compute::utils::http::BaseClient;
+use serde_json::json;
+
 
 #[cfg(feature = "synthesis")]
 use dkn_compute::workers::synthesis::*;
+
+#[cfg(feature = "search_python")]
+use dkn_compute::workers::search_python::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -42,6 +50,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "synthesis",
         tokio::time::Duration::from_millis(1000),
     ));
+
+    #[cfg(feature = "search_python")]
+    {
+        tracker.spawn(search_worker(
+            node.clone(),
+            "search_python", // topic?
+            tokio::time::Duration::from_millis(1000),
+        ));
+    }
 
     tracker.close(); // close tracker after spawning everything
 

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 /// A wrapper for GET, POST and DELETE requests.
 #[derive(Debug, Clone)]
 pub struct BaseClient {
-    pub(super) base_url: String,
+    base_url: String,
     client: Client,
 }
 
@@ -79,6 +79,10 @@ impl BaseClient {
             .await?;
 
         res.error_for_status()
+    }
+
+    pub fn get_base_url(&self) -> String {
+        self.base_url.clone()
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod crypto;
 pub mod filter;
+pub mod http;
 
 use std::time::{Duration, SystemTime};
 use tokio::signal::unix::{signal, SignalKind};

--- a/src/waku/mod.rs
+++ b/src/waku/mod.rs
@@ -1,4 +1,3 @@
-mod base;
 pub mod message;
 mod relay;
 
@@ -8,7 +7,9 @@ use std::env;
 
 use crate::errors::NodeResult;
 
-use self::{base::BaseClient, relay::RelayClient};
+use crate::utils::http::BaseClient;
+
+use self::relay::RelayClient;
 use serde::{Deserialize, Serialize};
 
 /// Waku [REST API](https://waku-org.github.io/waku-rest-api) wrapper.
@@ -97,6 +98,6 @@ mod tests {
         env::set_var("DKN_WAKU_URL", "im-a-host:1337");
 
         let waku = WakuClient::new(None);
-        assert_eq!(waku.base.base_url, "im-a-host:1337");
+        assert_eq!(waku.base.get_base_url(), "im-a-host:1337");
     }
 }

--- a/src/waku/relay.rs
+++ b/src/waku/relay.rs
@@ -1,4 +1,4 @@
-use crate::{errors::NodeResult, waku::BaseClient};
+use crate::{errors::NodeResult, utils::http::BaseClient};
 use urlencoding;
 
 use super::message::WakuMessage;

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -1,3 +1,4 @@
 pub mod diagnostic;
 pub mod heartbeat;
 pub mod synthesis;
+pub mod search_python;

--- a/src/workers/search_python.rs
+++ b/src/workers/search_python.rs
@@ -1,0 +1,147 @@
+use std::time::Duration;
+use std::sync::Arc;
+use serde_json::json;
+
+use crate::{
+    compute::payload::TaskRequestPayload,
+    node::DriaComputeNode,
+    utils::get_current_time_nanos,
+    utils::http::BaseClient,
+    waku::message::WakuMessage,
+    config::DriaComputeNodeConfig,
+};
+
+
+/// # Search Payload
+///
+/// A synthesis task is the task of putting a prompt to an LLM and obtaining many results, essentially growing the number of data points in a dataset,
+/// hence creating synthetic data.
+type SearchPayload = TaskRequestPayload<String>;
+
+pub fn search_worker(
+    node: Arc<DriaComputeNode>,
+    topic: &'static str,
+    sleep_amount: Duration,
+) -> tokio::task::JoinHandle<()> {
+
+    let config = node.config.clone();
+    let http_client = BaseClient::new(config.SEARCH_AGENT_URL.to_string());
+
+    tokio::spawn(async move {
+        node.subscribe_topic(topic).await;
+
+        loop {
+            tokio::select! {
+                _ = node.cancellation.cancelled() => {
+                    if let Err(e) = node.unsubscribe_topic(topic).await {
+                        log::error!("Error unsubscribing from {}: {}\nContinuing anyway.", topic, e);
+                    }
+                    break;
+                }
+                _ = tokio::time::sleep(sleep_amount) => {
+                    let mut tasks = Vec::new();
+                    if let Ok(messages) = node.process_topic(topic, true).await {
+                        if messages.is_empty() {
+                            continue;
+                        }
+                        log::info!("Received {} search-python tasks.", messages.len());
+
+                        for message in messages {
+                            match message.parse_payload::<SearchPayload>(true) {
+                                Ok(task) => {
+                                    // check deadline
+                                    if get_current_time_nanos() >= task.deadline {
+                                        log::debug!("{}", format!("Skipping {} due to deadline.", task.task_id));
+                                        continue;
+                                    }
+
+                                    // check task inclusion
+                                    match node.is_tasked(&task.filter) {
+                                        Ok(is_tasked) => {
+                                            if is_tasked {
+                                                log::debug!("{}", format!("Skipping {} due to filter.", task.task_id));
+                                                continue;
+                                            }
+                                        },
+                                        Err(e) => {
+                                            log::error!("Error checking task inclusion: {}", e);
+                                            continue;
+                                        }
+                                    }
+
+                                    tasks.push(task);
+                                },
+                                Err(e) => {
+                                    log::error!("Error parsing payload: {}", e);
+                                    continue;
+                                }
+                            }
+                        }
+                    }
+                    // Set node to busy
+                    node.set_busy(true);
+
+                    for task in tasks {
+                        // parse public key
+                        let task_public_key = match hex::decode(&task.public_key) {
+                            Ok(public_key) => public_key,
+                            Err(e) => {
+                                log::error!("Error parsing public key: {}", e);
+                                continue;
+                            }
+                        };
+
+                        let body = json!({
+                            "query": task.input,
+                            "with_manager": config.SEARCH_AGENT_MANAGER,
+                        });                    
+                        let r = match http_client.post("search", body).await{
+                            Ok(response) => response,
+                            Err(e) => {
+                                eprintln!("Error sending search query to search-agent-python: {:?}", e);
+                                continue;
+                            }
+                        };
+
+                        let search_result = match r.text().await{
+                            Ok(response) => response,
+                            Err(e) => {
+                                eprintln!("Error parsing search-agent-python response: {:?}", e);
+                                continue;
+                            }
+                        };
+
+                        // create h||s||e payload
+                        let payload = match node.create_payload(search_result, &task_public_key) {
+                            Ok(payload) => payload,
+                            Err(e) => {
+                                log::error!("Error creating payload: {}", e);
+                                continue;
+                            }
+                        };
+
+                        // stringify payload
+                        let payload_str = match payload.to_string() {
+                            Ok(payload_str) => payload_str,
+                            Err(e) => {
+                                log::error!("Error stringifying payload: {}", e);
+                                continue;
+                            }
+                        };
+
+                        // send result to Waku network
+                        let message = WakuMessage::new(payload_str, &task.task_id);
+                        if let Err(e) = node.send_message_once(message)
+                            .await {
+                                log::error!("Error sending message: {}", e);
+                                continue;
+                            }
+                    }
+
+                    // Set node to not busy
+                    node.set_busy(false);
+                }
+            }
+        }
+    })
+}


### PR DESCRIPTION
This pr introduces a `search_python` task for using `https://github.com/firstbatchxyz/dria-searching-agent` with http requests. 
- search worker added to `src/workers/search_python.rs`
- Base http client moved from `src/waku/base.rs` to `src/utils/http.rs`
- Dria-search-agent and its dependencies added to docker-compose with `search-python` profile