### PR TITLE
LangChain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,12 +3,13 @@ ETH_CLIENT_ADDRESS="https://sepolia.infura.io/v3/123aa110320f4aec179150fba1e1b1b
 ETH_TESTNET_KEY=<YOUR_SECRET_KEY> # Secret key of your compute node (32 byte, hexadecimal).
 RLN_RELAY_CRED_PASSWORD="" # Password for the RLN relay credentials.
 WAKU_URL="http://127.0.0.1:8645" # default
-EXTRA_ARGS="" # anything extra for Waku here
+WAKU_EXTRA_ARGS="" # anything extra for Waku here
 
 ## DRIA ##
-DKN_WALLET_SECRET_KEY=$(ETH_TESTNET_KEY) # Dria uses the same key as Waku
+DKN_WALLET_SECRET_KEY=${ETH_TESTNET_KEY} # Dria uses the same key as Waku
 DKN_ADMIN_PUBLIC_KEY=<DRIA_PUBLIC_KEY> # Public key of Dria (33-byte compressed, hexadecimal).
-DKN_TASKS="synthesis,feature" # comma separated task1,task2,task3,...
+DKN_TASKS=synthesis # comma separated task1,task2,task3,...
+DKN_SYNTHESIS_LLM_TYPE=Ollama # Ollama | OpenAI
 
 ## OLLAMA ##
 OLLAMA_MODEL=orca-mini # default, see https://ollama.com/library for available models
@@ -16,7 +17,7 @@ OLLAMA_HOST="http://127.0.0.1" # default
 OLLAMA_PORT="11434" # default
 
 ## SEARCH AGENT ##
-AGENT_MODEL_PROVIDER="Ollama" # OpenAI | Claude | Ollama, case-sensitive!
+AGENT_MODEL_PROVIDER="Ollama" # OpenAI | Claude | Ollama
 AGENT_MODEL_NAME="phi3"
 ANTHROPIC_API_KEY="api-key"
 OPENAI_API_KEY="api-key"

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,8 @@
 ## WAKU ## 
-# RPC URL for accessing testnet via HTTP. Below is a dummy, use your own!
-ETH_CLIENT_ADDRESS="https://sepolia.infura.io/v3/123aa110320f4aec179150fba1e1b1b1" 
+ETH_CLIENT_ADDRESS="https://sepolia.infura.io/v3/123aa110320f4aec179150fba1e1b1b1" # RPC URL, this is dummy; use your own!
 ETH_TESTNET_KEY=<YOUR_SECRET_KEY> # Secret key of your compute node (32 byte, hexadecimal).
 RLN_RELAY_CRED_PASSWORD="" # Password for the RLN relay credentials.
-DKN_WAKU_URL="http://127.0.0.1:8645" # default
+WAKU_URL="http://127.0.0.1:8645" # default
 EXTRA_ARGS="" # anything extra for Waku here
 
 ## DRIA ##
@@ -12,9 +11,9 @@ DKN_ADMIN_PUBLIC_KEY=<DRIA_PUBLIC_KEY> # Public key of Dria (33-byte compressed,
 DKN_TASKS="synthesis,feature" # comma separated task1,task2,task3,...
 
 ## OLLAMA ##
-DKN_OLLAMA_MODEL=orca-mini # default, see https://ollama.com/library for available models
-DKN_OLLAMA_HOST="http://127.0.0.1" # default
-DKN_OLLAMA_PORT="11434" # default
+OLLAMA_MODEL=orca-mini # default, see https://ollama.com/library for available models
+OLLAMA_HOST="http://127.0.0.1" # default
+OLLAMA_PORT="11434" # default
 
 ## SEARCH AGENT ##
 AGENT_MODEL_PROVIDER="Ollama" # OpenAI | Claude | Ollama, case-sensitive!

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-compute"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64 0.22.0",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom 0.2.14",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -78,6 +79,21 @@ name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anstream"
@@ -128,16 +144,136 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-convert"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d416feee97712e43152cd42874de162b8f9b77295b1c85e5d92725cc8310bae"
+dependencies = [
+ "async-trait",
+]
+
+[[package]]
+name = "async-openai"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007f03f7e27271451af57ced242d6adfa04204d1275a91ec0952bf441fd8d102"
+dependencies = [
+ "async-convert",
+ "backoff",
+ "base64 0.22.0",
+ "bytes",
+ "derive_builder",
+ "futures",
+ "rand 0.8.5",
+ "reqwest 0.12.4",
+ "reqwest-eventsource",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.59",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.59",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.59",
+]
+
+[[package]]
+name = "auto_enums"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1899bfcfd9340ceea3533ea157360ba8fa864354eccbceab58e1006ecab35393"
+dependencies = [
+ "derive_utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.59",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.14",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
 
 [[package]]
 name = "backtrace"
@@ -162,9 +298,30 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -197,6 +354,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +393,18 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "cipher"
@@ -278,6 +458,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +518,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b3df4f93e5fbbe73ec01ec8d3f68bba73107993a5b1e7519273c32db9b0d5be"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.11.2",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.59",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +579,103 @@ dependencies = [
  "byteorder",
  "fnv",
  "rand 0.7.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.59",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.59",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.59",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.59",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_utils"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61bb5a1014ce6dfc2a378578509abe775a5aa06bff584a547555d9efdb81b926"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -354,12 +709,14 @@ dependencies = [
  "fastbloom-rs",
  "hex",
  "hex-literal",
+ "langchain-rust",
  "libsecp256k1",
  "log",
- "ollama-rs",
+ "ollama-rs 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ollama-rs 0.1.9 (git+https://github.com/pepperoni21/ollama-rs.git?branch=master)",
  "parking_lot",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.4",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -368,6 +725,21 @@ dependencies = [
  "tokio-util",
  "url",
  "urlencoding",
+]
+
+[[package]]
+name = "dtoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbaceec3c6e4211c79e7b1800fb9680527106beb2f9c51904a3210c03a448c74"
+dependencies = [
+ "dtoa",
 ]
 
 [[package]]
@@ -387,6 +759,18 @@ dependencies = [
  "typenum",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "ego-tree"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a68a4904193147e0a8dec3314640e6db742afd5f6e634f428a6af230d9b3591"
+
+[[package]]
+name = "either"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "encoding_rs"
@@ -437,6 +821,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7493d4c459da9f84325ad297371a6b2b8a162800873a22e3b6b6512e61d18c05"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastbloom-rs"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +864,16 @@ name = "fastrand"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+
+[[package]]
+name = "flate2"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -491,12 +906,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -506,6 +947,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
 name = "futures-macro"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,7 +971,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -529,17 +987,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -550,6 +1027,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -593,6 +1079,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,7 +1114,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 1.1.0",
  "indexmap",
  "slab",
  "tokio",
@@ -620,6 +1131,12 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -679,6 +1196,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,12 +1242,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -707,8 +1269,8 @@ checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -719,10 +1281,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -733,15 +1325,45 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "httparse",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.29",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -752,7 +1374,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.3.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -769,9 +1391,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -779,6 +1401,35 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -810,10 +1461,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -837,6 +1506,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "langchain-rust"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bccb555d11abcf4e18189433821aaee48affe8b56a4528d553d7358ddf419a39"
+dependencies = [
+ "async-openai",
+ "async-recursion",
+ "async-stream",
+ "async-trait",
+ "csv",
+ "futures",
+ "futures-util",
+ "glob",
+ "html-escape",
+ "log",
+ "lopdf",
+ "mockito",
+ "ollama-rs 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "readability",
+ "regex",
+ "reqwest 0.12.4",
+ "reqwest-eventsource",
+ "scraper",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "strum_macros",
+ "text-splitter",
+ "thiserror",
+ "tiktoken-rs",
+ "tokio",
+ "tokio-stream",
+ "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -900,6 +1606,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +1634,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "lopdf"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e775e4ee264e8a87d50a9efef7b67b4aa988cf94e75630859875fc347e6c872b"
+dependencies = [
+ "chrono",
+ "encoding_rs",
+ "flate2",
+ "itoa",
+ "linked-hash-map",
+ "log",
+ "md5",
+ "nom",
+ "pom",
+ "rayon",
+ "time",
+ "weezl",
+]
+
+[[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
+dependencies = [
+ "log",
+ "phf 0.10.1",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9521dd6750f8e80ee6c53d65e2e4656d7de37064f3a7a5d2d11d05df93839c2"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "tendril",
+ "xml5ever",
+]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +1702,22 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -954,6 +1740,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockito"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6e023aa5bdf392aa06c78e4a4e6d498baab5138d0c993503350ebbc37bf1e"
+dependencies = [
+ "assert-json-diff",
+ "colored",
+ "futures-core",
+ "hyper 0.14.29",
+ "log",
+ "rand 0.8.5",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1774,37 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -993,9 +1829,22 @@ dependencies = [
 [[package]]
 name = "ollama-rs"
 version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53581ab78176ff3ae830a43236f485fc90d7f472d0081dddc45d8605e1301954"
+dependencies = [
+ "reqwest 0.12.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "ollama-rs"
+version = "0.1.9"
 source = "git+https://github.com/pepperoni21/ollama-rs.git?branch=master#56e8157d98d4185bc171fe9468d3d09bc56e9dd3"
 dependencies = [
- "reqwest",
+ "reqwest 0.12.4",
  "serde",
  "serde_json",
  "url",
@@ -1036,7 +1885,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1087,6 +1936,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.11.2",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared 0.11.2",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.59",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,7 +2032,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1137,10 +2066,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "pom"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c972d8f86e943ad532d0b04e8965a749ad1d18bb981a9c7b3ae72fe7fd7744b"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -1149,6 +2099,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8746739f11d39ce5ad5c2520a9b75285310dbfe78c541ccf832d38615765aec0"
+dependencies = [
+ "bitflags 2.5.0",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -1232,6 +2193,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "readability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56596e20a6d3cf715182d9b6829220621e6e985cec04d00410cee29821b4220"
+dependencies = [
+ "html5ever",
+ "lazy_static",
+ "markup5ever_rcdom",
+ "regex",
+ "reqwest 0.11.27",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,22 +2266,20 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-tls",
- "hyper-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -1295,7 +2288,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1308,7 +2301,88 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "base64 0.22.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-rustls",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "winreg 0.52.0",
+]
+
+[[package]]
+name = "reqwest-eventsource"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "reqwest 0.12.4",
+ "thiserror",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.14",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1316,6 +2390,12 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -1331,6 +2411,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,9 +2458,26 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
@@ -1366,6 +2499,32 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scraper"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b80b33679ff7a0ea53d37f3b39de77ea0c75b12c5805ac43ec0c33b3051af1b"
+dependencies = [
+ "ahash",
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "once_cell",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -1391,6 +2550,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "selectors"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
+dependencies = [
+ "bitflags 2.5.0",
+ "cssparser",
+ "derive_more",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.10.1",
+ "phf_codegen",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,7 +2585,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1431,6 +2609,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d036d71a959e00c77a63538b90a6c2390969f9772b096ea837205c6bd0491a44"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1477,6 +2664,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,10 +2701,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared 0.10.0",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7993a8e3a9e88a00351486baae9522c91b123a088f76469e5bd5cc17198ea87"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.59",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1558,6 +2834,102 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
+]
+
+[[package]]
+name = "text-splitter"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab9dc04b7cf08eb01c07c272bf699fa55679a326ddf7dd075e14094efc80fb9"
+dependencies = [
+ "ahash",
+ "auto_enums",
+ "either",
+ "itertools",
+ "once_cell",
+ "pulldown-cmark",
+ "regex",
+ "strum",
+ "thiserror",
+ "tiktoken-rs",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.59",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c314e7ce51440f9e8f5a497394682a57b7c323d0f4d0a6b1b13c429056e0e234"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "bstr",
+ "fancy-regex",
+ "lazy_static",
+ "parking_lot",
+ "rustc-hash",
+]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +2955,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -1598,7 +2971,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1608,6 +2981,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1663,7 +3058,19 @@ checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1688,6 +3095,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,6 +3125,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,6 +3145,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1734,6 +3168,18 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8parse"
@@ -1795,7 +3241,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
  "wasm-bindgen-shared",
 ]
 
@@ -1829,7 +3275,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1841,6 +3287,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,6 +3307,21 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "weezl"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1991,12 +3465,33 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "xml5ever"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4034e1d05af98b51ad7214527730626f019682d797ba38b51689212118d8e650"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
 ]
 
 [[package]]
@@ -2028,5 +3523,11 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ ollama-rs = "0.1.9"
 colored = "2.1.0"
 rand = "0.8.5"
 
-# fixed version of ollama-rs for benchmarks
+# TODO: fixed version of ollama-rs for benchmarks, remove this when the new version is released
 ollama-rs-master = { package = "ollama-rs", git = "https://github.com/pepperoni21/ollama-rs.git", branch = "master" }
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,6 @@ readme = "README.md"
 [features]
 default = []
 
-# search agent type
-search_python = [] # uses Python container for Search Agent
-
 # test features
 waku_test = []
 ollama_test = []
@@ -48,6 +45,9 @@ sha3 = "0.10.8"
 
 # connects with Ollama running locally, uses latest master branch
 ollama-rs = { git = "https://github.com/pepperoni21/ollama-rs.git", branch = "master" }
+langchain-rust = { version = "4.2.0", features = ["ollama"] }
+# TODO: used with LangChain due to version compatibility problems
+ollama-rs-old = { package = "ollama-rs", version = "0.1.9" }
 
 [dev-dependencies]
 colored = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkn-compute"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
@@ -43,15 +43,16 @@ fastbloom-rs = "0.5.9"
 sha2 = "0.10.8"
 sha3 = "0.10.8"
 
-# connects with Ollama running locally, uses latest master branch
-ollama-rs = { git = "https://github.com/pepperoni21/ollama-rs.git", branch = "master" }
+# llm stuff
 langchain-rust = { version = "4.2.0", features = ["ollama"] }
-# TODO: used with LangChain due to version compatibility problems
-ollama-rs-old = { package = "ollama-rs", version = "0.1.9" }
+ollama-rs = "0.1.9"
 
 [dev-dependencies]
 colored = "2.1.0"
 rand = "0.8.5"
+
+# fixed version of ollama-rs for benchmarks
+ollama-rs-master = { package = "ollama-rs", git = "https://github.com/pepperoni21/ollama-rs.git", branch = "master" }
 
 [[example]]
 name = "ollama"

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You have several alternatives to use Ollama:
 - `docker compose --profile ollama-rocm up -d` will launch Ollama container with ROCM support, for AMD gpus.
 - For Apple Silicon, you must install Ollama (e.g. `brew install ollama`) and launch the server (`ollama serve`) in another terminal, and then simply `docker compose up -d`.
 
-You can decide on a model to use by changing `DKN_OLLAMA_MODEL` variable, such as `DKN_OLLAMA_MODEL=llama3`. See [Ollama library](https://ollama.com/library) for the catalog of models.
+You can decide on a model to use by changing `OLLAMA_MODEL` variable, such as `OLLAMA_MODEL=llama3`. See [Ollama library](https://ollama.com/library) for the catalog of models.
 
 ## Run from Source
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Tasks are enabled or disabled via the `DKN_TASKS` environment variable. Task nam
 
 We are using a reduced version of [nwaku-compose](https://github.com/waku-org/nwaku-compose) for the Waku node. It only uses the RELAY protocol, and STORE is disabled. The respective files are under the [waku](./waku/) folder.
 
-By default, there are no static peers, but you can specify them using duplicate `--staticnode` arguments within the `EXTRA_ARGS` variable which is passed to the Waku node, that is:
+By default, there are no static peers, but you can specify them using duplicate `--staticnode` arguments within the `WAKU_EXTRA_ARGS` variable which is passed to the Waku node, that is:
 
 ```sh
-EXTRA_ARGS="--staticnode=/ip4/foobar/... --staticnode=/ip4/bazboo/..."
+WAKU_EXTRA_ARGS="--staticnode=/ip4/foobar/... --staticnode=/ip4/bazboo/..."
 ```
 
 ## Usage

--- a/compose.yml
+++ b/compose.yml
@@ -18,12 +18,13 @@ services:
   compute:
     build: "./"
     environment:
-      DKN_OLLAMA_HOST: "http://host.docker.internal"
-      DKN_OLLAMA_PORT: "11434"
-      DKN_OLLAMA_MODEL: ${DKN_OLLAMA_MODEL:-phi3}
-      DKN_WAKU_URL: "http://host.docker.internal:8645"
       DKN_WALLET_SECRET_KEY: ${ETH_TESTNET_KEY}
       DKN_ADMIN_PUBLIC_KEY: "0208ef5e65a9c656a6f92fb2c770d5d5e2ecffe02a6aade19207f75110be6ae658"
+      DKN_TASKS: ${DKN_TASKS}
+      WAKU_URL: "http://host.docker.internal:8645"
+      OLLAMA_HOST: "http://host.docker.internal"
+      OLLAMA_PORT: "11434"
+      OLLAMA_MODEL: ${OLLAMA_MODEL:-phi3}
       RUST_LOG: "info"
       SEARCH_AGENT_URL: "http://search-agent:5000"
       SEARCH_AGENT_MANAGER: true
@@ -31,6 +32,7 @@ services:
       - dkn-search-node-python-network
     depends_on:
       - search-agent
+      - nwaku # TODO: in the future we may run Waku with a different compose, so this can be removed at that step
 
   # Waku Node
   nwaku:

--- a/examples/benchmarks/ollama.rs
+++ b/examples/benchmarks/ollama.rs
@@ -60,7 +60,7 @@ async fn main() {
     };
 
     print_title();
-    let mut results = Vec::new();
+    let mut results: Vec<BenchmarkResult> = Vec::new();
     let mut num_prompts = HashMap::new();
     for (prompt_num, prompt) in prompts.iter().enumerate() {
         // println!("{}{}: {}", "Prompt #".blue(), prompt_num, prompt);

--- a/examples/benchmarks/ollama.rs
+++ b/examples/benchmarks/ollama.rs
@@ -1,10 +1,12 @@
 use colored::Colorize;
-use dkn_compute::compute::ollama::use_model_with_prompt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::env;
 use std::fs::File;
 use std::io::Read;
+
+#[path = "../common/ollama.rs"]
+mod common;
 
 /// A `println!` macro that only prints when the `debug_assertions` flag is set, i.e. it wont print when `--release` is used.
 #[allow(unused)]
@@ -65,7 +67,7 @@ async fn main() {
     for (prompt_num, prompt) in prompts.iter().enumerate() {
         // println!("{}{}: {}", "Prompt #".blue(), prompt_num, prompt);
         for model in models {
-            let (generation, duration) = use_model_with_prompt(model, prompt).await;
+            let (generation, duration) = common::use_model_with_prompt(model, prompt).await;
 
             let result = BenchmarkResult {
                 prompt_num,

--- a/examples/common/ollama.rs
+++ b/examples/common/ollama.rs
@@ -1,5 +1,5 @@
 use dkn_compute::{
-    compute::ollama::{DEFAULT_OLLAMA_HOST, DEFAULT_OLLAMA_PORT},
+    config::constants::{DEFAULT_OLLAMA_HOST, DEFAULT_OLLAMA_PORT},
     utils::get_current_time_nanos,
 };
 use ollama_rs_master::{

--- a/examples/common/ollama.rs
+++ b/examples/common/ollama.rs
@@ -1,17 +1,18 @@
-use dkn_compute::{compute::ollama::OllamaClient, utils::get_current_time_nanos};
-use ollama_rs::generation::completion::{request::GenerationRequest, GenerationResponse};
-use tokio_util::sync::CancellationToken;
+use dkn_compute::{
+    compute::ollama::{DEFAULT_OLLAMA_HOST, DEFAULT_OLLAMA_PORT},
+    utils::get_current_time_nanos,
+};
+use ollama_rs_master::{
+    generation::completion::{request::GenerationRequest, GenerationResponse},
+    Ollama,
+};
 
 /// A shorthand function to invoke a prompt using a given model with Ollama.
 pub async fn use_model_with_prompt(
     model: &str,
     prompt: &str,
 ) -> (GenerationResponse, tokio::time::Duration) {
-    let ollama = OllamaClient::new(None, None, Some(model.to_string()));
-    ollama
-        .setup(CancellationToken::default())
-        .await
-        .expect("Should pull model");
+    let ollama = Ollama::new(DEFAULT_OLLAMA_HOST, DEFAULT_OLLAMA_PORT);
 
     let time = get_current_time_nanos();
     let prompt = prompt.to_string();
@@ -19,11 +20,7 @@ pub async fn use_model_with_prompt(
     log::debug!("Generating with prompt: {}", prompt);
 
     let gen_req = GenerationRequest::new(model.to_string(), prompt);
-    let gen_res = ollama
-        .client
-        .generate(gen_req)
-        .await
-        .expect("should generate");
+    let gen_res = ollama.generate(gen_req).await.expect("should generate");
 
     log::debug!("Generated response: {}", gen_res.response);
 

--- a/examples/common/ollama.rs
+++ b/examples/common/ollama.rs
@@ -1,0 +1,34 @@
+use dkn_compute::{compute::ollama::OllamaClient, utils::get_current_time_nanos};
+use ollama_rs::generation::completion::{request::GenerationRequest, GenerationResponse};
+use tokio_util::sync::CancellationToken;
+
+/// A shorthand function to invoke a prompt using a given model with Ollama.
+pub async fn use_model_with_prompt(
+    model: &str,
+    prompt: &str,
+) -> (GenerationResponse, tokio::time::Duration) {
+    let ollama = OllamaClient::new(None, None, Some(model.to_string()));
+    ollama
+        .setup(CancellationToken::default())
+        .await
+        .expect("Should pull model");
+
+    let time = get_current_time_nanos();
+    let prompt = prompt.to_string();
+
+    log::debug!("Generating with prompt: {}", prompt);
+
+    let gen_req = GenerationRequest::new(model.to_string(), prompt);
+    let gen_res = ollama
+        .client
+        .generate(gen_req)
+        .await
+        .expect("should generate");
+
+    log::debug!("Generated response: {}", gen_res.response);
+
+    let time_diff = get_current_time_nanos() - time;
+    let duration = tokio::time::Duration::from_nanos(time_diff as u64);
+
+    (gen_res, duration)
+}

--- a/examples/prompt.rs
+++ b/examples/prompt.rs
@@ -1,5 +1,7 @@
 use colored::Colorize;
-use dkn_compute::compute::ollama::use_model_with_prompt;
+
+#[path = "./common/ollama.rs"]
+mod common;
 
 #[tokio::main]
 async fn main() {
@@ -41,7 +43,7 @@ Please ensure that your generated examples are realistic, coherent, and free of 
 Output must be use only JSON-formatted synthetic datasets.
 Do not include instruction, only entry. Do not add any comment.";
 
-    let (generation, duration) = use_model_with_prompt(model, prompt).await;
+    let (generation, duration) = common::use_model_with_prompt(model, prompt).await;
     println!(
         "\n{} ({}: {}ms): {}",
         "Response".green(),

--- a/src/compute/llm.rs
+++ b/src/compute/llm.rs
@@ -1,0 +1,60 @@
+use langchain_rust::language_models::llm::LLM;
+use tokio_util::sync::CancellationToken;
+
+use super::ollama::create_ollama;
+use super::openai::create_openai;
+
+#[derive(Debug, Default)]
+pub enum LLMType {
+    #[default]
+    Ollama,
+    OpenAI,
+}
+
+impl From<String> for LLMType {
+    fn from(value: String) -> Self {
+        match value.to_lowercase().as_str().trim() {
+            "ollama" => Self::Ollama,
+            "openai" => Self::OpenAI,
+            _ => {
+                log::warn!("Unknown LLM type: {}, defaulting.", value);
+                Self::default()
+            }
+        }
+    }
+}
+
+impl From<&LLMType> for String {
+    fn from(value: &LLMType) -> Self {
+        match value {
+            LLMType::Ollama => "Ollama".to_string(),
+            LLMType::OpenAI => "OpenAI".to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for LLMType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", String::from(self))
+    }
+}
+
+/// Creates an LLM of the given type, which is a LangChain object.
+///
+/// The respective setups of the LLMs are done within this function,
+/// e.g. Ollama will pull the model if it does not exist locally.
+pub async fn create_llm(
+    llm: LLMType,
+    cancellation: CancellationToken,
+) -> Result<Box<dyn LLM>, String> {
+    match llm {
+        LLMType::Ollama => {
+            let client = create_ollama(cancellation.clone()).await?;
+            Ok(Box::new(client))
+        }
+        LLMType::OpenAI => {
+            let client = create_openai();
+            Ok(Box::new(client))
+        }
+    }
+}

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -1,3 +1,4 @@
+pub mod llm;
 pub mod ollama;
 pub mod openai;
 pub mod payload;

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -1,5 +1,4 @@
 pub mod ollama;
+pub mod openai;
 pub mod payload;
-
-#[cfg(feature = "search_python")]
 pub mod search_python;

--- a/src/compute/ollama.rs
+++ b/src/compute/ollama.rs
@@ -1,151 +1,106 @@
-use langchain_rust::language_models::llm::LLM;
 use std::env;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 use langchain_rust::llm::client::Ollama as OllamaLang; // langchain Ollama client
-use ollama_rs::Ollama; // our Ollama-rs instance
-use ollama_rs_old::Ollama as OllamaOld; // langchain's Ollama-rs instance
-
-use ollama_rs::error::OllamaError;
+use ollama_rs::Ollama; // langchain's Ollama-rs instance
 
 pub const DEFAULT_OLLAMA_HOST: &str = "http://127.0.0.1";
 pub const DEFAULT_OLLAMA_PORT: u16 = 11434;
 pub const DEFAULT_OLLAMA_MODEL: &str = "orca-mini";
 
-/// A wrapper for the Ollama API.
-#[derive(Debug, Clone)]
-pub struct OllamaClient {
-    pub client: Ollama,
-    pub(crate) langchain: OllamaLang,
-    pub(crate) model: String,
+/// Creates an Ollama client, pulls the model if it does not exist locally.
+pub async fn create_ollama(cancellation: CancellationToken) -> Result<OllamaLang, String> {
+    let host = env::var("OLLAMA_HOST").unwrap_or(DEFAULT_OLLAMA_HOST.to_string());
+
+    let port = env::var("OLLAMA_PORT")
+        .and_then(|port_str| {
+            port_str
+                .parse::<u16>()
+                .map_err(|_| env::VarError::NotPresent)
+        })
+        .unwrap_or(DEFAULT_OLLAMA_PORT);
+
+    let model = env::var("OLLAMA_MODEL").unwrap_or(DEFAULT_OLLAMA_MODEL.to_string());
+
+    let client = Ollama::new(host, port);
+    log::info!("Ollama URL: {}", client.uri());
+    log::info!("Ollama Model: {}", model);
+
+    pull_model(&client, &model, cancellation).await?;
+
+    Ok(OllamaLang::new(Arc::new(client), model, None))
 }
 
-impl Default for OllamaClient {
-    fn default() -> Self {
-        Self::new(
-            Some(DEFAULT_OLLAMA_HOST.to_string()),
-            Some(DEFAULT_OLLAMA_PORT),
-            Some(DEFAULT_OLLAMA_MODEL.to_string()),
-        )
-    }
-}
+pub async fn pull_model(
+    client: &Ollama,
+    model: &str,
+    cancellation: CancellationToken,
+) -> Result<(), String> {
+    log::info!("Checking local models");
+    let local_models = client
+        .list_local_models()
+        .await
+        .map_err(|e| format!("{:?}", e))?;
 
-impl OllamaClient {
-    /// Creates a new Ollama client.
-    ///
-    /// Reads `OLLAMA_HOST`, `OLLAMA_PORT` and `OLLAMA_MODEL` from the environment, and defaults if not provided.
-    pub fn new(host: Option<String>, port: Option<u16>, model: Option<String>) -> Self {
-        let host = host
-            .unwrap_or_else(|| env::var("OLLAMA_HOST").unwrap_or(DEFAULT_OLLAMA_HOST.to_string()));
-
-        let port = port.unwrap_or_else(|| {
-            env::var("OLLAMA_PORT")
-                .and_then(|port_str| {
-                    port_str
-                        .parse::<u16>()
-                        .map_err(|_| env::VarError::NotPresent)
-                })
-                .unwrap_or(DEFAULT_OLLAMA_PORT)
-        });
-
-        let model = model.unwrap_or_else(|| {
-            env::var("OLLAMA_MODEL").unwrap_or(DEFAULT_OLLAMA_MODEL.to_string())
-        });
-
-        let client = Ollama::new(host.clone(), port);
-        log::info!("Ollama URL: {}", client.uri());
-        log::info!("Ollama Model: {}", model);
-
-        let client_old = OllamaOld::new(host, port);
-        let langchain = OllamaLang::new(Arc::new(client_old), model.clone(), None);
-
-        Self {
-            langchain,
-            client,
-            model,
+    let num_local_modals = local_models.len();
+    if num_local_modals == 0 {
+        log::info!("No local models found.");
+    } else {
+        let mut message = format!("{}{}", num_local_modals, " local models found:");
+        for model in local_models.iter() {
+            message.push_str(format!("\n{}", model.name).as_str())
         }
+        log::info!("{}", message);
     }
 
-    /// Lists local models for diagnostic, and pulls the configured model.
-    pub async fn setup(&self, cancellation: CancellationToken) -> Result<(), OllamaError> {
-        log::info!("Checking local models");
-        let local_models = self.client.list_local_models().await?;
-        let num_local_modals = local_models.len();
-        if num_local_modals == 0 {
-            log::info!("No local models found.");
-        } else {
-            let mut message = format!("{}{}", num_local_modals, " local models found:");
-            for model in local_models.iter() {
-                message.push_str(format!("\n{}", model.name).as_str())
-            }
-            log::info!("{}", message);
-        }
-
-        log::info!("Pulling model: {}, this may take a while...", self.model);
-        const MAX_RETRIES: usize = 3;
-        let mut retry_count = 0; // retry count for edge case
-        while let Err(e) = self.client.pull_model((&self.model).into(), false).await {
-            // edge case: invalid model is given
-            if e.to_string().contains("file does not exist") {
-                return Err(OllamaError::from(
-                    "Invalid Ollama model, please check your environment variables.".to_string(),
-                ));
-            } else if retry_count < MAX_RETRIES {
-                log::error!(
-                    "Error setting up Ollama: {}\nRetrying in 5 seconds ({}/{}).",
-                    e,
-                    retry_count,
-                    MAX_RETRIES
-                );
-                tokio::select! {
-                    _ = cancellation.cancelled() => return Ok(()),
-                    _ = tokio::time::sleep(tokio::time::Duration::from_secs(5)) => {
-                        retry_count += 1; // Increment the retry counter
-                        continue;
-                    }
+    log::info!("Pulling model: {}, this may take a while...", model);
+    const MAX_RETRIES: usize = 3;
+    let mut retry_count = 0; // retry count for edge case
+    while let Err(e) = client.pull_model(model.to_string(), false).await {
+        // edge case: invalid model is given
+        if e.to_string().contains("file does not exist") {
+            return Err(
+                "Invalid Ollama model, please check your environment variables.".to_string(),
+            );
+        } else if retry_count < MAX_RETRIES {
+            log::error!(
+                "Error setting up Ollama: {}\nRetrying in 5 seconds ({}/{}).",
+                e,
+                retry_count,
+                MAX_RETRIES
+            );
+            tokio::select! {
+                _ = cancellation.cancelled() => return Ok(()),
+                _ = tokio::time::sleep(tokio::time::Duration::from_secs(5)) => {
+                    retry_count += 1; // Increment the retry counter
+                    continue;
                 }
-            } else {
-                // Handling the case when maximum retries are exceeded
-                log::error!("Maximum retry attempts exceeded, stopping retries.");
-                return Err(OllamaError::from(
-                    "Maximum retry attempts exceeded.".to_string(),
-                ));
             }
+        } else {
+            // Handling the case when maximum retries are exceeded
+            log::error!("Maximum retry attempts exceeded, stopping retries.");
+            return Err("Maximum retry attempts exceeded.".to_string());
         }
-        log::info!("Pulled {}", self.model);
-
-        Ok(())
     }
+    log::info!("Pulled {}", model);
 
-    /// Generates a result using the local LLM.
-    pub async fn generate(&self, prompt: String) -> Result<String, OllamaError> {
-        log::debug!("Generating with prompt: {}", prompt);
-
-        let response = self
-            .langchain
-            .invoke(&prompt)
-            .await
-            .map_err(|e| OllamaError::from(format!("{:?}", e)))?;
-
-        log::debug!("Generated response: {}", response);
-        Ok(response)
-    }
+    Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
 
-    #[test]
-    fn test_ollama_config() {
-        env::set_var("OLLAMA_HOST", "http://im-a-host");
-        env::set_var("OLLAMA_MODEL", "phi3");
-        env::remove_var("OLLAMA_PORT");
+//     #[test]
+//     fn test_ollama_config() {
+//         env::set_var("OLLAMA_HOST", "http://im-a-host");
+//         env::set_var("OLLAMA_MODEL", "phi3");
+//         env::remove_var("OLLAMA_PORT");
 
-        // will use default port, but read host and model from env
-        let ollama = OllamaClient::new(None, None, None);
-        assert_eq!(ollama.client.url_str(), "http://im-a-host:11434/");
-        assert_eq!(ollama.model, "phi3");
-    }
-}
+//         // will use default port, but read host and model from env
+//         let ollama = OllamaClient::new(None, None, None);
+//         assert_eq!(ollama.client.url_str(), "http://im-a-host:11434/");
+//         assert_eq!(ollama.model, "phi3");
+//     }
+// }

--- a/src/compute/openai.rs
+++ b/src/compute/openai.rs
@@ -1,0 +1,90 @@
+use std::env;
+
+use langchain_rust::language_models::LLMError;
+use langchain_rust::llm::OpenAIConfig;
+use langchain_rust::{language_models::llm::LLM, llm::openai::OpenAI};
+
+/// A wrapper for the OpenAI API, using LangChain.
+///
+/// Will check for the following environment variables:
+///
+/// - `OPENAI_API_BASE`
+/// - `OPENAI_API_KEY`
+/// - `OPENAI_ORG_ID`
+/// - `OPENAI_PROJECT_ID`
+#[derive(Clone)]
+pub struct OpenAIClient {
+    pub(crate) client: OpenAI<OpenAIConfig>,
+}
+
+impl Default for OpenAIClient {
+    fn default() -> Self {
+        Self {
+            client: OpenAI::default(),
+        }
+    }
+}
+
+impl OpenAIClient {
+    pub fn new() -> Self {
+        let mut config = OpenAIConfig::default();
+
+        match env::var("OPENAI_API_BASE") {
+            Ok(api_base) => {
+                config = config.with_api_base(api_base);
+            }
+            Err(_) => {}
+        }
+
+        match env::var("OPENAI_API_KEY") {
+            Ok(api_key) => {
+                config = config.with_api_key(api_key);
+            }
+            Err(_) => {}
+        }
+
+        match env::var("OPENAI_ORG_ID") {
+            Ok(org_id) => {
+                config = config.with_org_id(org_id);
+            }
+            Err(_) => {}
+        }
+
+        match env::var("OPENAI_PROJECT_ID") {
+            Ok(project_id) => {
+                config = config.with_project_id(project_id);
+            }
+            Err(_) => {}
+        }
+
+        Self {
+            client: OpenAI::new(config),
+        }
+    }
+
+    pub async fn generate(&self, prompt: String) -> Result<String, LLMError> {
+        self.client.invoke(prompt.as_str()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[ignore] // cargo test --package dkn-compute --lib --all-features -- compute::openai::tests::test_openai --exact --show-output --ignored
+    async fn test_openai() {
+        let value = "FOOBARFOOBAR"; // use with your own key, with caution
+        env::set_var("OPENAI_API_KEY", value);
+
+        let openai = OpenAIClient::new();
+
+        let prompt = "Once upon a time, in a land far away, there was a dragon.";
+        let response = openai
+            .client
+            .invoke(prompt)
+            .await
+            .expect("Should generate response");
+        println!("{}", response);
+    }
+}

--- a/src/compute/openai.rs
+++ b/src/compute/openai.rs
@@ -3,6 +3,8 @@ use std::env;
 use langchain_rust::llm::openai::OpenAI;
 use langchain_rust::llm::OpenAIConfig;
 
+use crate::config::constants::*;
+
 /// Creates an OpenAI langchain client.
 ///
 /// Will check for the following environment variables:
@@ -14,16 +16,16 @@ use langchain_rust::llm::OpenAIConfig;
 pub fn create_openai() -> OpenAI<OpenAIConfig> {
     let mut config = OpenAIConfig::default();
 
-    if let Ok(api_base) = env::var("OPENAI_API_BASE") {
+    if let Ok(api_base) = env::var(OPENAI_API_BASE_URL) {
         config = config.with_api_base(api_base);
     }
-    if let Ok(api_key) = env::var("OPENAI_API_KEY") {
+    if let Ok(api_key) = env::var(OPENAI_API_KEY) {
         config = config.with_api_key(api_key);
     }
-    if let Ok(org_id) = env::var("OPENAI_ORG_ID") {
+    if let Ok(org_id) = env::var(OPENAI_ORG_ID) {
         config = config.with_org_id(org_id);
     }
-    if let Ok(project_id) = env::var("OPENAI_PROJECT_ID") {
+    if let Ok(project_id) = env::var(OPENAI_PROJECT_ID) {
         config = config.with_project_id(project_id);
     }
 
@@ -39,7 +41,7 @@ mod tests {
     #[ignore] // cargo test --package dkn-compute --lib --all-features -- compute::openai::tests::test_openai --exact --show-output --ignored
     async fn test_openai() {
         let value = "FOOBARFOOBAR"; // use with your own key, with caution
-        env::set_var("OPENAI_API_KEY", value);
+        env::set_var(OPENAI_API_KEY, value);
 
         let openai = create_openai();
 

--- a/src/compute/search_python.rs
+++ b/src/compute/search_python.rs
@@ -20,14 +20,13 @@ impl Default for SearchPythonClient {
 impl SearchPythonClient {
     pub fn new() -> Self {
         let url = env::var("SEARCH_AGENT_URL").unwrap_or_default();
-        let with_manager = match env::var("SEARCH_AGENT_MANAGER")
-            .unwrap_or_default()
-            .to_lowercase()
-            .as_str()
-        {
-            "1" | "true" | "yes" => true,
-            _ => false,
-        };
+        let with_manager = matches!(
+            env::var("SEARCH_AGENT_MANAGER")
+                .unwrap_or_default()
+                .to_lowercase()
+                .as_str(),
+            "1" | "true" | "yes"
+        );
 
         let client = BaseClient::new(url.to_string());
 

--- a/src/compute/search_python.rs
+++ b/src/compute/search_python.rs
@@ -1,4 +1,4 @@
-use crate::utils::http::BaseClient;
+use crate::{config::constants::*, utils::http::BaseClient};
 use serde_json::json;
 use std::env;
 
@@ -19,9 +19,9 @@ impl Default for SearchPythonClient {
 
 impl SearchPythonClient {
     pub fn new() -> Self {
-        let url = env::var("SEARCH_AGENT_URL").unwrap_or_default();
+        let url = env::var(SEARCH_AGENT_URL).unwrap_or_default();
         let with_manager = matches!(
-            env::var("SEARCH_AGENT_MANAGER")
+            env::var(SEARCH_AGENT_MANAGER)
                 .unwrap_or_default()
                 .to_lowercase()
                 .as_str(),

--- a/src/config/constants.rs
+++ b/src/config/constants.rs
@@ -1,0 +1,34 @@
+use hex_literal::hex;
+
+// DKN
+pub const DKN_ADMIN_PUBLIC_KEY: &str = "DKN_ADMIN_PUBLIC_KEY";
+pub const DKN_WALLET_SECRET_KEY: &str = "DKN_WALLET_SECRET_KEY";
+pub const DKN_WALLET_PUBLIC_KEY: &str = "DKN_WALLET_PUBLIC_KEY";
+pub const DKN_WALLET_ADDRESS: &str = "DKN_WALLET_ADDRESS";
+pub const DKN_TASKS: &str = "DKN_TASKS";
+pub const DKN_SYNTHESIS_LLM_TYPE: &str = "DKN_SYNTHESIS_LLM_TYPE";
+/// 33 byte compressed public key of secret key from hex(b"dria) * 8, dummy only
+pub const DEFAULT_DKN_ADMIN_PUBLIC_KEY: &[u8; 33] =
+    &hex!("0208ef5e65a9c656a6f92fb2c770d5d5e2ecffe02a6aade19207f75110be6ae658");
+
+/// 32 byte secret key hex(b"node") * 8, dummy only
+pub const DEFAULT_DKN_WALLET_SECRET_KEY: &[u8; 32] =
+    &hex!("6e6f64656e6f64656e6f64656e6f64656e6f64656e6f64656e6f64656e6f6465");
+
+// Ollama
+pub const OLLAMA_HOST: &str = "OLLAMA_HOST";
+pub const OLLAMA_PORT: &str = "OLLAMA_PORT";
+pub const OLLAMA_MODEL: &str = "OLLAMA_MODEL";
+pub const DEFAULT_OLLAMA_HOST: &str = "http://127.0.0.1";
+pub const DEFAULT_OLLAMA_PORT: u16 = 11434;
+pub const DEFAULT_OLLAMA_MODEL: &str = "phi3";
+
+// OpenAI
+pub const OPENAI_API_BASE_URL: &str = "OPENAI_API_BASE_URL";
+pub const OPENAI_API_KEY: &str = "OPENAI_API_KEY";
+pub const OPENAI_ORG_ID: &str = "OPENAI_ORG_ID";
+pub const OPENAI_PROJECT_ID: &str = "OPENAI_PROJECT_ID";
+
+// Search Agent (Python)
+pub const SEARCH_AGENT_URL: &str = "SEARCH_AGENT_URL";
+pub const SEARCH_AGENT_MANAGER: &str = "SEARCH_AGENT_MANAGER";

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -53,7 +53,12 @@ impl DriaComputeNodeConfig {
 
         let address = to_address(&public_key);
 
-        log::info!("Address: 0x{}", hex::encode(address));
+        log::info!(
+            "Admin Public Key: 0x{}",
+            hex::encode(admin_public_key.serialize_compressed())
+        );
+
+        log::info!("Node Address:     0x{}", hex::encode(address));
         log::info!(
             "Node Public Key:  0x{}",
             hex::encode(public_key.serialize_compressed())
@@ -62,10 +67,6 @@ impl DriaComputeNodeConfig {
             "Node Secret Key:  0x{}{}",
             hex::encode(&secret_key.serialize()[0..1]),
             ".".repeat(64)
-        );
-        log::info!(
-            "Admin Public Key: 0x{}",
-            hex::encode(admin_public_key.serialize_compressed())
         );
 
         Self {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,17 +1,11 @@
+pub mod constants;
 pub mod tasks;
 
 use crate::utils::crypto::to_address;
+use constants::*;
 use ecies::PublicKey;
 use libsecp256k1::{PublicKeyFormat, SecretKey};
 use std::env;
-
-/// 33 byte compressed public key of secret key from hex(b"dria) * 8, dummy only
-pub const DEFAULT_DKN_ADMIN_PUBLIC_KEY: &[u8; 33] =
-    &hex_literal::hex!("0208ef5e65a9c656a6f92fb2c770d5d5e2ecffe02a6aade19207f75110be6ae658");
-
-/// 32 byte secret key hex(b"node") * 8, dummy only
-pub const DEFAULT_DKN_WALLET_SECRET_KEY: &[u8; 32] =
-    &hex_literal::hex!("6e6f64656e6f64656e6f64656e6f64656e6f64656e6f64656e6f64656e6f6465");
 
 #[allow(non_snake_case)]
 #[derive(Debug, Clone)]
@@ -28,7 +22,7 @@ pub struct DriaComputeNodeConfig {
 
 impl DriaComputeNodeConfig {
     pub fn new() -> Self {
-        let secret_key = match env::var("DKN_WALLET_SECRET_KEY") {
+        let secret_key = match env::var(DKN_WALLET_SECRET_KEY) {
             Ok(secret_env) => {
                 let secret_dec =
                     hex::decode(secret_env).expect("Secret key should be 32-bytes hex encoded.");
@@ -41,7 +35,7 @@ impl DriaComputeNodeConfig {
         let public_key = PublicKey::from_secret_key(&secret_key);
 
         let admin_public_key = PublicKey::parse_slice(
-            hex::decode(env::var("DKN_ADMIN_PUBLIC_KEY").unwrap_or_default())
+            hex::decode(env::var(DKN_ADMIN_PUBLIC_KEY).unwrap_or_default())
                 .unwrap_or_default()
                 .as_slice(),
             Some(PublicKeyFormat::Compressed),
@@ -91,7 +85,7 @@ mod tests {
     #[test]
     fn test_config() {
         env::set_var(
-            "DKN_WALLET_SECRET_KEY",
+            DKN_WALLET_SECRET_KEY,
             "6e6f64656e6f64656e6f64656e6f64656e6f64656e6f64656e6f64656e6f6465",
         );
         let cfg = DriaComputeNodeConfig::new();

--- a/src/config/tasks.rs
+++ b/src/config/tasks.rs
@@ -29,14 +29,13 @@ impl DriaComputeNodeTasks {
         let mut synthesis = false;
         let mut search = false;
 
-        let tasks: Vec<&str> = vec.split(",").collect();
+        let tasks: Vec<&str> = vec.split(',').collect();
         for task in tasks {
             match task.trim().to_lowercase().as_str() {
                 TASK_SYNTHESIS => synthesis = true,
                 TASK_SEARCH => search = true,
                 _ => {
                     log::warn!("Unknown task: {}", task);
-                    ()
                 }
             }
         }
@@ -50,23 +49,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parser_1() {
+    fn test_parsers() {
         env::set_var("DKN_TASKS", "fsfdshk,SynthEsis,fkdshfjsdk");
         let tasks = DriaComputeNodeTasks::new();
         assert!(tasks.synthesis);
         assert!(!tasks.search);
-    }
 
-    #[test]
-    fn test_parser_2() {
         env::set_var("DKN_TASKS", "fsfdshk, fdgsdg, search ");
         let tasks = DriaComputeNodeTasks::new();
         assert!(!tasks.synthesis);
         assert!(tasks.search);
-    }
 
-    #[test]
-    fn test_parser_3() {
         env::set_var("DKN_TASKS", ",,,");
         let tasks = DriaComputeNodeTasks::new();
         assert!(!tasks.synthesis);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,14 @@
-use dkn_compute::config::tasks::DriaComputeNodeTasks;
-use dkn_compute::utils::wait_for_termination;
-use dkn_compute::{config::DriaComputeNodeConfig, node::DriaComputeNode};
 use std::env;
 use std::sync::Arc;
-use tokio_util::sync::CancellationToken;
-use tokio_util::task::TaskTracker;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+
+use dkn_compute::{
+    config::{
+        constants::DKN_SYNTHESIS_LLM_TYPE, tasks::DriaComputeNodeTasks, DriaComputeNodeConfig,
+    },
+    node::DriaComputeNode,
+    utils::wait_for_termination,
+};
 
 use dkn_compute::workers::diagnostic::*;
 use dkn_compute::workers::heartbeat::*;
@@ -45,7 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             node.clone(),
             "synthesis",
             tokio::time::Duration::from_millis(1000),
-            env::var("DKN_SYNTHESIS_LLM_TYPE").ok(),
+            env::var(DKN_SYNTHESIS_LLM_TYPE).ok(),
         ));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,8 @@ use tokio_util::task::TaskTracker;
 
 use dkn_compute::workers::diagnostic::*;
 use dkn_compute::workers::heartbeat::*;
-use dkn_compute::workers::synthesis::*;
-
-#[cfg(feature = "search_python")]
 use dkn_compute::workers::search_python::*;
+use dkn_compute::workers::synthesis::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -50,15 +48,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if tasks.search {
-        #[cfg(feature = "search_python")]
+        // TODO: add a feature / env var to enable/disable search_python
+        // and use search_rust instead
         tracker.spawn(search_worker(
             node.clone(),
             "search_python",
             tokio::time::Duration::from_millis(1000),
         ));
-
-        #[cfg(not(feature = "search_python"))]
-        log::error!("search_python feature is not enabled, skipping search worker.");
     }
 
     // close tracker after spawning everything

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use dkn_compute::config::tasks::DriaComputeNodeTasks;
 use dkn_compute::utils::wait_for_termination;
 use dkn_compute::{config::DriaComputeNodeConfig, node::DriaComputeNode};
+use std::env;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
@@ -44,6 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             node.clone(),
             "synthesis",
             tokio::time::Duration::from_millis(1000),
+            env::var("DKN_SYNTHESIS_LLM_TYPE").ok(),
         ));
     }
 

--- a/src/waku/mod.rs
+++ b/src/waku/mod.rs
@@ -1,7 +1,7 @@
 pub mod message;
 mod relay;
 
-const DEFAULT_DKN_WAKU_URL: &str = "http://127.0.0.1:8645";
+const DEFAULT_WAKU_URL: &str = "http://127.0.0.1:8645";
 
 use std::env;
 
@@ -28,9 +28,8 @@ impl Default for WakuClient {
 impl WakuClient {
     /// Creates a new instance of WakuClient.
     pub fn new(url: Option<String>) -> Self {
-        let url: String = url.unwrap_or_else(|| {
-            env::var("DKN_WAKU_URL").unwrap_or(DEFAULT_DKN_WAKU_URL.to_string())
-        });
+        let url: String =
+            url.unwrap_or_else(|| env::var("WAKU_URL").unwrap_or(DEFAULT_WAKU_URL.to_string()));
         log::info!("Waku URL: {}", url);
 
         let base = BaseClient::new(url);
@@ -95,7 +94,7 @@ mod tests {
 
     #[test]
     fn test_waku_config() {
-        env::set_var("DKN_WAKU_URL", "im-a-host:1337");
+        env::set_var("WAKU_URL", "im-a-host:1337");
 
         let waku = WakuClient::new(None);
         assert_eq!(waku.base.get_base_url(), "im-a-host:1337");

--- a/src/workers/heartbeat.rs
+++ b/src/workers/heartbeat.rs
@@ -84,7 +84,7 @@ pub fn heartbeat_worker(
 #[cfg(test)]
 mod tests {
     use crate::{
-        config::DEFAULT_DKN_ADMIN_PUBLIC_KEY,
+        config::constants::DEFAULT_DKN_ADMIN_PUBLIC_KEY,
         node::DriaComputeNode,
         utils::{
             crypto::{sha256hash, to_address},

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -1,6 +1,4 @@
 pub mod diagnostic;
 pub mod heartbeat;
-pub mod synthesis;
-
-#[cfg(feature = "search_python")]
 pub mod search_python;
+pub mod synthesis;

--- a/src/workers/synthesis.rs
+++ b/src/workers/synthesis.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::{
-    compute::{ollama::OllamaClient, payload::TaskRequestPayload},
+    compute::{llm::create_llm, payload::TaskRequestPayload},
     node::DriaComputeNode,
     utils::get_current_time_nanos,
     waku::message::WakuMessage,
@@ -18,13 +18,19 @@ pub fn synthesis_worker(
     node: Arc<DriaComputeNode>,
     topic: &'static str,
     sleep_amount: Duration,
+    llm_type: Option<String>,
 ) -> tokio::task::JoinHandle<()> {
-    let ollama = OllamaClient::new(None, None, None);
-
     tokio::spawn(async move {
-        if let Err(e) = ollama.setup(node.cancellation.clone()).await {
-            log::error!("Could not setup Ollama: {}", e);
-        }
+        let llm_type = llm_type.unwrap_or_default().into();
+        log::info!("Using {} for {}", llm_type, topic);
+
+        let llm = match create_llm(llm_type, node.cancellation.clone()).await {
+            Ok(llm) => llm,
+            Err(e) => {
+                log::error!("Could not create LLM: {}", e);
+                return;
+            }
+        };
 
         node.subscribe_topic(topic).await;
 
@@ -92,7 +98,7 @@ pub fn synthesis_worker(
                         };
 
                         // get prompt result from Ollama
-                        let llm_result = match ollama.generate(task.input).await {
+                        let llm_result = match llm.invoke(&task.input).await {
                             Ok(result) => result,
                             Err(e) => {
                                 log::error!("Error generating prompt result: {}", e);

--- a/src/workers/synthesis.rs
+++ b/src/workers/synthesis.rs
@@ -101,7 +101,7 @@ pub fn synthesis_worker(
                         };
 
                         // create h||s||e payload
-                        let payload = match node.create_payload(llm_result.response, &task_public_key) {
+                        let payload = match node.create_payload(llm_result, &task_public_key) {
                             Ok(payload) => payload,
                             Err(e) => {
                                 log::error!("Error creating payload: {}", e);

--- a/tests/ollama_test.rs
+++ b/tests/ollama_test.rs
@@ -1,6 +1,10 @@
 #[cfg_attr(test, cfg(feature = "ollama_test"))]
 mod ollama_test {
+    use std::env;
+
+    use dkn_compute::compute::ollama::create_ollama;
     use langchain_rust::{language_models::llm::LLM, llm::client::Ollama};
+    use tokio_util::sync::CancellationToken;
 
     #[tokio::test]
     async fn test_ollama_prompt() {
@@ -19,16 +23,13 @@ mod ollama_test {
         println!("Prompt: {}\n\nResponse:{}", prompt, response);
     }
 
-    // TODO: move to pull model test
-    // #[tokio::test]
-    // async fn test_ollama_bad_model() {
-    //     let model = "thismodeldoesnotexistlol".to_string();
-    //     let ollama = OllamaClient::new(None, None, Some(model));
-
-    //     let setup_res = ollama.setup(CancellationToken::default()).await;
-    //     assert!(
-    //         setup_res.is_err(),
-    //         "Should give error due to non-existing model."
-    //     );
-    // }
+    #[tokio::test]
+    async fn test_ollama_bad_model() {
+        env::set_var("OLLAMA_MODEL", "thismodeldoesnotexistlol".to_string());
+        let setup_res = create_ollama(CancellationToken::default()).await;
+        assert!(
+            setup_res.is_err(),
+            "Should give error due to non-existing model."
+        );
+    }
 }

--- a/tests/ollama_test.rs
+++ b/tests/ollama_test.rs
@@ -1,12 +1,11 @@
 #[cfg_attr(test, cfg(feature = "ollama_test"))]
 mod ollama_test {
-    use dkn_compute::compute::ollama::OllamaClient;
-    use tokio_util::sync::CancellationToken;
+    use langchain_rust::{language_models::llm::LLM, llm::client::Ollama};
 
     #[tokio::test]
     async fn test_ollama_prompt() {
         let model = "orca-mini".to_string();
-        let ollama = OllamaClient::new(None, None, Some(model));
+        let ollama = Ollama::default().with_model(model);
         let prompt = "The sky appears blue during the day because of a process called scattering. \
                 When sunlight enters the Earth's atmosphere, it collides with air molecules such as oxygen and nitrogen. \
                 These collisions cause some of the light to be absorbed or reflected, which makes the colors we see appear more vivid and vibrant. \
@@ -14,21 +13,22 @@ mod ollama_test {
                 What may be the question this answer?".to_string();
 
         let response = ollama
-            .generate(prompt.clone())
+            .invoke(&prompt)
             .await
             .expect("Should generate response");
         println!("Prompt: {}\n\nResponse:{}", prompt, response);
     }
 
-    #[tokio::test]
-    async fn test_ollama_bad_model() {
-        let model = "thismodeldoesnotexistlol".to_string();
-        let ollama = OllamaClient::new(None, None, Some(model));
+    // TODO: move to pull model test
+    // #[tokio::test]
+    // async fn test_ollama_bad_model() {
+    //     let model = "thismodeldoesnotexistlol".to_string();
+    //     let ollama = OllamaClient::new(None, None, Some(model));
 
-        let setup_res = ollama.setup(CancellationToken::default()).await;
-        assert!(
-            setup_res.is_err(),
-            "Should give error due to non-existing model."
-        );
-    }
+    //     let setup_res = ollama.setup(CancellationToken::default()).await;
+    //     assert!(
+    //         setup_res.is_err(),
+    //         "Should give error due to non-existing model."
+    //     );
+    // }
 }

--- a/tests/ollama_test.rs
+++ b/tests/ollama_test.rs
@@ -13,11 +13,11 @@ mod ollama_test {
                 Blue is one of the brightest colors that is scattered the most by the atmosphere, making it visible to our eyes during the day. \
                 What may be the question this answer?".to_string();
 
-        let gen_res = ollama
+        let response = ollama
             .generate(prompt.clone())
             .await
             .expect("Should generate response");
-        println!("Prompt: {}\n\nResponse:{}", prompt, gen_res.response);
+        println!("Prompt: {}\n\nResponse:{}", prompt, response);
     }
 
     #[tokio::test]


### PR DESCRIPTION
- Moved OpenAI and Ollama llms under the same trait, i.e. LangChain's `LLM` trait. This way, each worker can simply choose the type of LLM that they would like to use for the task, and have access to the LLM trait within the worker to call `invoke` and such.
- Renamed some `.env` variables.
- Minor refactors.
- Removed `search_python` feature.
- Fixed lint errors.
- Moved the master-branch Ollama-rs into examples only & as a dev-dependency, should make it easier for #32 when Ollama-rs is released.