### PR TITLE
Start script and compose enhancements

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -25,13 +25,10 @@ services:
       OLLAMA_HOST: "http://host.docker.internal"
       OLLAMA_PORT: "11434"
       OLLAMA_MODEL: ${OLLAMA_MODEL:-phi3}
-      RUST_LOG: "info"
-      SEARCH_AGENT_URL: "http://search-agent:5000"
+      RUST_LOG: "${RUST_LOGS:-info}"
+      SEARCH_AGENT_URL: "http://host.docker.internal:5000"
       SEARCH_AGENT_MANAGER: true
-    networks:
-      - dkn-search-node-python-network
     depends_on:
-      - search-agent
       - nwaku # TODO: in the future we may run Waku with a different compose, so this can be removed at that step
 
   # Waku Node
@@ -63,8 +60,6 @@ services:
     entrypoint: sh
     command:
       - /opt/run_node.sh
-    networks:
-      - dkn-search-node-python-network
     # profiles: [waku] # TODO: in the future we may run Waku with a different compose, keeping this comment here
 
   # Ollama Container (CPU)
@@ -73,9 +68,7 @@ services:
     ports:
       - 11434:11434
     volumes:
-      - ollama:~/.ollama
-    networks:
-      - dkn-search-node-python-network
+      - ~/.ollama:/root/.ollama
     profiles: [ollama-cpu]
 
   # Ollama Container (ROCM)
@@ -84,12 +77,10 @@ services:
     ports:
       - 11434:11434
     volumes:
-      - ollama:/root/.ollama
+      - ~/.ollama:/root/.ollama
     devices:
       - "/dev/kfd"
       - "/dev/dri"
-    networks:
-      - dkn-search-node-python-network
     profiles: [ollama-rocm]
 
   # Ollama Container (CUDA)
@@ -98,7 +89,7 @@ services:
     ports:
       - 11434:11434
     volumes:
-      - ollama:/root/.ollama
+      - ~/.ollama:/root/.ollama
     deploy:
       resources:
         reservations:
@@ -106,8 +97,6 @@ services:
             - driver: nvidia
               count: 1
               capabilities: [gpu]
-    networks:
-      - dkn-search-node-python-network
     profiles: [ollama-cuda]
 
   # Qdrant VectorDB for Search Agent
@@ -118,8 +107,6 @@ services:
       - "6334:6334"
     volumes:
       - ./qdrant_storage:/qdrant/storage:z
-    networks:
-      - dkn-search-node-python-network
     profiles: [search-python]
 
   # Browser automation
@@ -129,12 +116,10 @@ services:
       - TOKEN=${BROWSERLESS_TOKEN}
     ports:
       - "3030:3000"
-    networks:
-      - dkn-search-node-python-network
     profiles: [search-python]
 
   search-agent:
-    image: dria-searching-agent:server
+    image: firstbatch/dria-searching-agent:latest
     ports:
       - 5000:5000
     environment:
@@ -147,21 +132,9 @@ services:
       BROWSERLESS_TOKEN: ${BROWSERLESS_TOKEN}
 
       OLLAMA_URL: http://host.docker.internal:11434
-      QDRANT_URL: http://qdrant:6333
-      BROWSERLESS_URL: http://browserless:3000
-    networks:
-      dkn-search-node-python-network:
+      QDRANT_URL: http://host.docker.internal:6333
+      BROWSERLESS_URL: http://host.docker.internal:3000
     profiles: [search-python]
-
-networks:
-  dkn-search-node-python-network:
-    name: dkn-search-node-python-network
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.30.0.0/24
-          gateway: 172.30.0.1
 
 volumes:
   ollama:

--- a/start.sh
+++ b/start.sh
@@ -122,7 +122,7 @@ handle_waku_args() {
         echo "No waku peer found"
     else
         waku_peers=""
-        for peer in $parsed_response; do
+        for peer in ${parsed_response[@]}; do
             waku_peers="${waku_peers}--staticnode=${peer} "
         done
         WAKU_EXTRA_ARGS+=(${waku_peers})
@@ -133,8 +133,8 @@ handle_waku_args() {
 handle_waku_args
 
 # prepare docker-compose commands
-COMPOSE_PROFILES=$(IFS=,; echo "${COMPOSE_PROFILES[*]}")
-WAKU_EXTRA_ARGS=$(IFS=,; echo "${WAKU_EXTRA_ARGS[*]}")
+COMPOSE_PROFILES=$(IFS=","; echo "${COMPOSE_PROFILES[*]}")
+WAKU_EXTRA_ARGS=$(IFS=" "; echo "${WAKU_EXTRA_ARGS[*]}")
 TASKS=$(IFS=,; echo "${TASKS[*]}")
 
 compose_command="docker-compose"
@@ -148,7 +148,6 @@ compose_down="${compose_command} down"
 # run docker-compose up
 echo "\n"
 echo "Starting in ${START_MODE} mode..."
-# TODO: echo "$compose_up"
 eval "${compose_up}"
 compose_exit_code=$?
 

--- a/start.sh
+++ b/start.sh
@@ -1,31 +1,62 @@
 #!/bin/sh
 
-# Description of command-line arguments:
-#   --background: Enables background mode for running the node
-# Example usage:
-#   ./start.sh --background
-# Required env-variables:
-#   DKN_TASKS: comma seperated list of one or more items from the below list:
-#       [synthesis,search,search-python]
+docs() {
+    echo "
+        Description of command-line arguments:
+            -b, --background: Enables background mode for running the node (default: FOREGROUND)
+            --search: Runs the node for the search tasks (default: false)
+            --synthesis: Runs the node for the synthesis tasks (default: false)
+            --local-ollama: Indicates the local Ollama environment is being used (default: false)
+            --dev: Sets the logging level to debug (default: info)
+            -h, --help: Displays this help message
+
+        At least one of --search or --synthesis is required
+
+        Example usage:
+            ./start.sh --search --local-ollama --dev
+    "
+    exit 0
+}
 
 WAKU_PEER_DISCOVERY_URL="" # TODO: url for getting a list of admin nodes in waku
-BACKGROUND=false
+
+START_MODE="FOREGROUND"
+COMPUTE_SEARCH=false
+COMPUTE_SYNTHESIS=false
+LOCAL_OLLAMA=false
+LOGS="info"
+COMPOSE_PROFILES=()
+TASKS=()
 
 echo "*** DKN - Compute Node ***"
 
+# handle command line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
-        --background) BACKGROUND=true ;;
-        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+        -b|--background) START_MODE="BACKGROUND" ;;
+        --search) COMPUTE_SEARCH=true ;;
+        --synthesis) COMPUTE_SYNTHESIS=true ;;
+        --local-ollama) LOCAL_OLLAMA=true ;;
+        --dev) LOGS="debug" ;;
+        -h|--help) docs ;;
+        *) echo "ERROR: Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
 done
 
 echo "Handling the environment..."
 
-COMPOSE_PROFILES=()
-# ollama profiles
-check_gpu() {
+ollama_profiles() {
+    # check local ollama
+    if [ "$LOCAL_OLLAMA" == true ]; then
+        if command -v ollama &> /dev/null; then
+            echo "Using local ollama"
+            return
+        else
+            echo "Ollama is not installed on this machine, using the docker-compose service"
+        fi
+    fi
+
     # check for cuda gpu
     if command -v nvidia-smi &> /dev/null; then
         if nvidia-smi &> /dev/null; then
@@ -44,27 +75,42 @@ check_gpu() {
         fi
     fi
 
-    echo "No compatible GPU detected, running on CPU"
+    # if there are no local ollama and gpu, use docker-compose with cpu profile
     COMPOSE_PROFILES+=("ollama-cpu")
     return
 }
-check_gpu
+ollama_profiles
 
 # compute-node profiles
-compute_node_profiles() {
-    # Check if DKN_TASKS is set
-    if [ -z "$DKN_TASKS" ]; then
-        echo "DKN_TASKS environment variable is not set"
-        return 1
+compute_options() {
+    if [ "$COMPUTE_SEARCH" = true ]; then
+        TASKS+=("search")
+        COMPOSE_PROFILES+=("search-python") # start with search-agent profile for search dependencies
     fi
+    if [ "$COMPUTE_SYNTHESIS" = true ]; then
+        TASKS+=("synthesis")
+    fi
+    if [ "$COMPUTE_SEARCH" = false ] && [ "$COMPUTE_SYNTHESIS" = false ]; then
+    # if no task type argument has given, check DKN_TASKS env var
+        if [ -n "$DKN_TASKS" ]; then
+            # split, iterate and validate given tasks in env var 
+            IFS=',' read -ra tsks <<< "$DKN_TASKS"
+            for ts in "${tsks[@]}"; do
+                if [ "$ts" = "search" ] || [ "$ts" = "search-python" ]; then
+                    TASKS+=("search")
+                    COMPOSE_PROFILES+=("search-python") 
+                elif [ "$ts" = "synthesis" ]; then
+                    TASKS+=("synthesis")
+                fi
+            done
 
-    IFS=',' read -ra modes <<< "$DKN_TASKS"
-    for mode in "${modes[@]}"; do
-        COMPOSE_PROFILES+=($mode)
-    done
-
+        else
+            echo "ERROR: No task type has given, --synthesis and/or --search flags are required"
+            exit 1
+        fi
+    fi
 }
-compute_node_profiles
+compute_options
 
 WAKU_EXTRA_ARGS=()
 handle_waku_args() {
@@ -75,9 +121,9 @@ handle_waku_args() {
     if [[ -z "$parsed_response" ]]; then
         echo "No waku peer found"
     else
-        waku_peers="--staticnode="
+        waku_peers=""
         for peer in $parsed_response; do
-            waku_peers="${waku_peers},${peer}"
+            waku_peers="${waku_peers}--staticnode=${peer} "
         done
         WAKU_EXTRA_ARGS+=(${waku_peers})
     fi
@@ -87,27 +133,39 @@ handle_waku_args() {
 handle_waku_args
 
 # prepare docker-compose commands
-compose_command="docker-compose"
 COMPOSE_PROFILES=$(IFS=,; echo "${COMPOSE_PROFILES[*]}")
 WAKU_EXTRA_ARGS=$(IFS=,; echo "${WAKU_EXTRA_ARGS[*]}")
-compose_command="WAKU_EXTRA_ARGS=\"${WAKU_EXTRA_ARGS}\" ${compose_command}"
+TASKS=$(IFS=,; echo "${TASKS[*]}")
+
+compose_command="docker-compose"
 compose_command="COMPOSE_PROFILES=\"${COMPOSE_PROFILES}\" ${compose_command}"
+compose_command="WAKU_EXTRA_ARGS=\"${WAKU_EXTRA_ARGS}\" ${compose_command}"
+compose_command="DKN_TASKS=\"${TASKS}\" ${compose_command}"
+compose_command="RUST_LOGS=\"${LOGS}\" ${compose_command}"
 compose_up="${compose_command} up -d"
 compose_down="${compose_command} down"
 
-# run docker-compose
+# run docker-compose up
 echo "\n"
-if [ "$BACKGROUND" == true ]; then
-    echo "Starting in background mode..."
-    eval "${compose_up} > /dev/null 2>&1"
-else
-    echo "Starting in attached mode..."
-    eval "${compose_up} > /dev/null 2>&1"
-    echo "Use Command-C to exit"
+echo "Starting in ${START_MODE} mode..."
+# TODO: echo "$compose_up"
+eval "${compose_up}"
+compose_exit_code=$?
+
+# handle docker-compose error
+if [ $compose_exit_code -ne 0 ]; then
+    echo "\nERROR: docker-compose"
+    exit $compose_exit_code
+fi
+
+# background/foreground mode
+if [ "$START_MODE" == "FOREGROUND" ]; then
+    echo "\nUse Command-C to exit"
+
     cleanup() {
         echo "\nShutting down..."
-        eval "${compose_down} > /dev/null 2>&1"
-        echo "bye"
+        eval "${compose_down}"
+        echo "\nbye"
         exit
     }
     # wait for Ctrl-C


### PR DESCRIPTION
Start script updates:
```
Description of command-line arguments:
        -b, --background: Enables background mode for running the node (default: FOREGROUND)
        --search: Runs the node for the search tasks (default: false)
        --synthesis: Runs the node for the synthesis tasks (default: false)
        --local-ollama: Indicates the local Ollama environment is being used (default: false)
        --dev: Sets the logging level to debug (default: info)
        -h, --help: Displays this help message
    At least one of --search or --synthesis is required
    Example usage:
        ./start.sh --search --local-ollama --dev
```
Docker-compose updates:
- Remove network creation and use default docker network
- Mount `~/.ollama` to ollama images
- Remove `search-agent` dependency on compute since `search-agent` is runs with a profile
- Pull search-agent image from dockerhub repo
- Env var updates