### PR TITLE
Refactor workers

### DIFF
--- a/src/compute/payload.rs
+++ b/src/compute/payload.rs
@@ -1,10 +1,7 @@
 use serde::{Deserialize, Serialize};
-use serde_json::{json, to_string};
 
 use crate::{errors::NodeResult, utils::filter::FilterPayload};
 
-/// # Dria Task Response
-///
 /// A computation task is the task of computing a result from a given input. The result is encrypted with the public key of the requester.
 /// Plain result is signed by the compute node's private key, and a commitment is computed from the signature and plain result.
 ///
@@ -22,12 +19,10 @@ pub struct TaskResponsePayload {
 
 impl TaskResponsePayload {
     pub fn to_string(&self) -> NodeResult<String> {
-        to_string(&json!(self)).map_err(|e| e.into())
+        serde_json::to_string(&serde_json::json!(self)).map_err(|e| e.into())
     }
 }
 
-/// # Dria Task Request
-///
 /// A generic task request, given by Dria.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -42,4 +37,11 @@ pub struct TaskRequestPayload<T> {
     pub(crate) filter: FilterPayload,
     /// The public key of the requester.
     pub(crate) public_key: String,
+}
+
+/// A parsed `TaskRequestPayload`.
+pub struct TaskRequest<T> {
+    pub(crate) task_id: String,
+    pub(crate) input: T,
+    pub(crate) public_key: Vec<u8>,
 }

--- a/src/workers/heartbeat.rs
+++ b/src/workers/heartbeat.rs
@@ -41,7 +41,6 @@ pub fn heartbeat_worker(
                         }
                     };
 
-
                     // we only care about the latest heartbeat
                     if let Some(message) = messages.last() {
                         if node.is_busy() {

--- a/src/workers/heartbeat.rs
+++ b/src/workers/heartbeat.rs
@@ -52,8 +52,7 @@ pub fn heartbeat_worker(
 
                         log::info!("Received: {}", message);
 
-                        let message = match message
-                        .parse_payload::<HeartbeatPayload>(true) {
+                        let message = match message.parse_payload::<HeartbeatPayload>(true) {
                             Ok(body) => {
                                 let uuid = body.uuid;
                                 let signature = node.sign_bytes(&sha256hash(uuid.as_bytes()));

--- a/src/workers/search_python.rs
+++ b/src/workers/search_python.rs
@@ -2,13 +2,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::{
-    compute::{payload::TaskRequestPayload, search_python::SearchPythonClient},
-    node::DriaComputeNode,
-    utils::get_current_time_nanos,
-    waku::message::WakuMessage,
+    compute::search_python::SearchPythonClient, node::DriaComputeNode, waku::message::WakuMessage,
 };
-
-type SearchPayload = TaskRequestPayload<String>;
 
 /// # Search
 ///
@@ -33,51 +28,22 @@ pub fn search_worker(
                     break;
                 }
                 _ = tokio::time::sleep(sleep_amount) => {
-                    let mut tasks = Vec::new();
-                    if let Ok(messages) = node.process_topic(topic, true).await {
-                        if messages.is_empty() {
+                    let tasks = match node.process_topic(topic, true).await {
+                        Ok(messages) => {
+                            if messages.is_empty() {
+                                continue;
+                            }
+                            log::info!("Received {} {} messages.",  messages.len(), topic);
+                            node.parse_messages::<String>(messages)
+                        }
+                        Err(e) => {
+                            log::error!("Error processing topic {}: {}", topic, e);
                             continue;
                         }
-                        log::info!("Received {} search-python tasks.", messages.len());
+                    };
 
-                        for message in messages {
-                            match message.parse_payload::<SearchPayload>(true) {
-                                Ok(task) => {
-                                    // check deadline
-                                    if get_current_time_nanos() >= task.deadline {
-                                        log::debug!("{}", format!("Skipping {} due to deadline.", task.task_id));
-                                        continue;
-                                    }
-
-                                    // check task inclusion
-                                    match node.is_tasked(&task.filter) {
-                                        Ok(is_tasked) => {
-                                            if is_tasked {
-                                                log::debug!("{}", format!("Skipping {} due to filter.", task.task_id));
-                                                continue;
-                                            }
-                                        },
-                                        Err(e) => {
-                                            log::error!("Error checking task inclusion: {}", e);
-                                            continue;
-                                        }
-                                    }
-
-                                    tasks.push(task);
-                                },
-                                Err(e) => {
-                                    log::error!("Error parsing payload: {}", e);
-                                    continue;
-                                }
-                            }
-                        }
-                    }
-
-                   // TODO: wait for busy lock
+                    log::info!("Received {} {} tasks.",  tasks.len(), topic);
                     node.set_busy(true);
-
-                    // sort tasks by deadline, closer deadline processed first
-                    tasks.sort_by(|a, b| a.deadline.cmp(&b.deadline));
                     for task in tasks {
                         // parse public key
                         let task_public_key = match hex::decode(&task.public_key) {


### PR DESCRIPTION
Both `search_python` and `synthesis` workers had a lot of duplicate code, these parts have now been moved within the `node` as a utility function. A `TaskRequest` struct has been added, which is the parsed form of `TaskRequestPayload`.

- `node.parse_messages` parses a list of messages into list of task requests, eliminating those that have past deadline / invalid public keys.
- `node.send_task_result` sends a task result to Waku, handling the payload creating and encryption and such.