### PR TITLE
Waku extra args from env

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -231,7 +231,8 @@ ollama_profiles() {
 }
 ollama_profiles
 
-WAKU_EXTRA_ARGS=()
+wake_arg_list=()
+# WAKU_EXTRA_ARGS=()
 WAKU_PEER_DISCOVERY_URL="" # TODO: url for getting a list of admin nodes in waku
 handle_waku_args() {
     # --staticnode
@@ -245,7 +246,11 @@ handle_waku_args() {
         for peer in ${parsed_response[@]}; do
             waku_peers="${waku_peers}--staticnode=${peer} "
         done
-        WAKU_EXTRA_ARGS+=(${waku_peers})
+        wake_arg_list+=(${waku_peers})
+    fi
+    wake_arg_list=$(IFS=" "; echo "${wake_arg_list[*]}")
+    if [ -n "$wake_arg_list" ]; then
+        WAKU_EXTRA_ARGS="${WAKU_EXTRA_ARGS} ${wake_arg_list}"
     fi
 
     # TODO: additional waku args here
@@ -258,7 +263,6 @@ handle_env_vars(){
     COMPOSE_PROFILES=$(IFS=","; echo "${COMPOSE_PROFILES[*]}")
     ENVVARS="COMPOSE_PROFILES=\"${COMPOSE_PROFILES}\" ${ENVVARS}"
 
-    WAKU_EXTRA_ARGS=$(IFS=" "; echo "${WAKU_EXTRA_ARGS[*]}")
     ENVVARS="WAKU_EXTRA_ARGS=\"${WAKU_EXTRA_ARGS}\" ${ENVVARS}"
 
     TASKS=$(IFS=,; echo "${TASKS[*]}")
@@ -292,7 +296,8 @@ COMPOSE_DOWN="${ENVVARS} ${COMPOSE_COMMAND} down"
 # run docker-compose up
 echo "\n"
 echo "Starting in ${START_MODE} mode..."
-eval "${COMPOSE_UP}"
+echo "${COMPOSE_UP}"
+# eval "${COMPOSE_UP}"
 compose_exit_code=$?
 
 # handle docker-compose error
@@ -301,16 +306,16 @@ if [ $compose_exit_code -ne 0 ]; then
     exit $compose_exit_code
 fi
 
-# background/foreground mode
-if [ "$START_MODE" == "FOREGROUND" ]; then
-    echo "\nUse Control-C to exit"
+# # background/foreground mode
+# if [ "$START_MODE" == "FOREGROUND" ]; then
+#     echo "\nUse Control-C to exit"
 
-    cleanup() {
-        echo "\nShutting down..."
-        eval "${COMPOSE_DOWN}"
-        echo "\nbye"
-        exit
-    }
-    # wait for Ctrl-C
-    ( trap cleanup SIGINT ; read -r -d '' _ </dev/tty )
-fi
+#     cleanup() {
+#         echo "\nShutting down..."
+#         eval "${COMPOSE_DOWN}"
+#         echo "\nbye"
+#         exit
+#     }
+#     # wait for Ctrl-C
+#     ( trap cleanup SIGINT ; read -r -d '' _ </dev/tty )
+# fi


### PR DESCRIPTION
quick fix for getting env-var value for `WAKU_EXTRA_ARGS` from env