### PR TITLE
Start script - more enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 .vscode
 .DS_Store
+/qdrant_storage

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ chmod +x start.sh
   - There are three Docker Compose Ollama options: `ollama-cpu`, `ollama-cuda`, and `ollama-rocm`. The start script will decide which option to use based on the host machine's GPU specifications.
 - Start script will run the containers in the background. You can check their logs either via the terminal or from [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 
-### (Alternative) Run from Source
+### Run from Source
 
 We are using Make as a wrapper for some scripts. You can see the available commands with:
 

--- a/README.md
+++ b/README.md
@@ -53,38 +53,53 @@ WAKU_EXTRA_ARGS="--staticnode=/ip4/foobar/... --staticnode=/ip4/bazboo/..."
 
 ## Usage
 
-Dria Compute Node is mainly expected to be executed using Docker Compose. The provided compose file will setup everything required. To start running a node, you must do the following:
+Dria Compute Node is mainly expected to be executed using `./start.sh`. To start running a node, you must do the following:
+
+### Initial Setup
+
+1. **Clone the repo**
+
+```bash
+git clone https://github.com/firstbatchxyz/dkn-compute-node
+```
 
 1. **Prepare Environment Variables**: Dria Compute Node makes use of several environment variables, some of which used by Waku itself as well. First, prepare you environment variable as given in [.env.example](./.env.example).
 
-1. **Fund an Ethereum Wallet with 0.1 Sepolia ETH**: Waku and Dria makes use of the same Ethereum wallet, and Waku uses RLN Relay protocol for further security within the network. If you have not registered to RLN protocol yet, register by running `./register_rln.sh`. If you have already registered, you will have a `keystore.json` which you can place under `./waku/keystore/keystore.json` in this directory. Your secret key will be provided at `ETH_TESTNET_KEY` variable. You can set an optional password at `RLN_RELAY_CRED_PASSWORD` as well to encrypt the keystore file, or to decrypt it if you already have one.
+1. **Fund an Ethereum Wallet with 0.1 Sepolia ETH**: Waku and Dria makes use of the same Ethereum wallet, and Waku uses RLN Relay protocol for further security within the network. If you have not registered to RLN protocol yet, register by running `./waku/register_rln.sh`. If you have already registered, you will have a `keystore.json` which you can place under `./waku/keystore/keystore.json` in this directory. Your secret key will be provided at `ETH_TESTNET_KEY` variable. You can set an optional password at `RLN_RELAY_CRED_PASSWORD` as well to encrypt the keystore file, or to decrypt it if you already have one.
 
 1. **Ethereum Client RPC**: To communicate with Sepolia, you need an RPC URL. You can use [Infura](https://app.infura.io/) or [Alchemy](https://www.alchemy.com/). Your URL will be provided at `ETH_CLIENT_ADDRESS` variable.
 
-With all of these steps completed, you should be able to start a node with:
+### Start the node
+
+With all setup steps completed, you should be able to start a node with `./start.sh`
 
 ```sh
-# clone the repo
-git clone https://github.com/firstbatchxyz/dkn-compute-node
+# Give exec permissions
+chmod +x start.sh
 
-# -d to run in background
-docker compose up -d
+# Check the available commands
+./start.sh --help
+
+# Example command for synthesis tasks
+./start.sh --synthesis --synthesis-model-provider=ollama --synthesis-model=phi3
+
+# Example command for search tasks 
+./start.sh --search --search-model-provider=openai --search-model=gpt-4o
+
+# Once you fill the .env file you can skip the given variables
+# For instance, assume we have DKN_TASKS=synthesis and DKN_SYNTHESIS_MODEL_PROVIDER=ollama in the .env file
+./start.sh --synthesis-model=llama3 # Only model name would be sufficient
+
+# Example command for simultaneous search and synthesis tasks
+./start.sh --synthesis --search
 ```
 
-With `-d` option, the containers will be running in the background. You can check their logs either via the terminal or from [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+- With the `--local-ollama=true` option (default), the compute node will use the local Ollama server on the host machine. If the server is not running, the start script will initiate it with `ollama serve` and terminate it when stopping the node.
+  - If `--local-ollama=false` or the local Ollama server is reachable, the compute node will use a Docker Compose service for it.
+  - There are three Docker Compose Ollama options: `ollama-cpu`, `ollama-cuda`, and `ollama-rocm`. The start script will decide which option to use based on the host machine's GPU specifications.
+- Start script will run the containers in the background. You can check their logs either via the terminal or from [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 
-### Ollama Configuration
-
-You have several alternatives to use Ollama:
-
-- `docker compose --profile ollama-cpu up -d` will launch Ollama container using CPU only.
-- `docker compose --profile ollama-cuda up -d` will launch Ollama container with CUDA support, for NVIDIA gpus.
-- `docker compose --profile ollama-rocm up -d` will launch Ollama container with ROCM support, for AMD gpus.
-- For Apple Silicon, you must install Ollama (e.g. `brew install ollama`) and launch the server (`ollama serve`) in another terminal, and then simply `docker compose up -d`.
-
-You can decide on a model to use by changing `OLLAMA_MODEL` variable, such as `OLLAMA_MODEL=llama3`. See [Ollama library](https://ollama.com/library) for the catalog of models.
-
-## Run from Source
+### (Alternative) Run from Source
 
 We are using Make as a wrapper for some scripts. You can see the available commands with:
 
@@ -94,8 +109,6 @@ make help
 
 You will need OpenSSL installed as well, see shorthand commands [here](https://github.com/sfackler/rust-openssl/issues/855#issuecomment-450057552).
 
-### Running Compute Node
-
 While running Waku and Ollama node elsewhere, you can run the compute node with:
 
 ```sh
@@ -103,7 +116,7 @@ make run      # info-level logs
 make debug    # debug-level logs
 ```
 
-## Docs
+#### Docs
 
 Open crate docs using:
 
@@ -111,7 +124,7 @@ Open crate docs using:
 make docs
 ```
 
-## Testing
+#### Testing
 
 Besides the unit tests, there are separate tests for Waku network, and for compute tasks such as Ollama.
 
@@ -121,7 +134,7 @@ make test-waku    # Waku tests (requires a running Waku node)
 make test-ollama  # Ollama tests (requires a running Ollama client)
 ```
 
-## Benchmarking
+#### Benchmarking
 
 To measure the speed of some Ollama models we have a benchmark that uses some models for a few prompts:
 
@@ -135,7 +148,7 @@ You can also benchmark these models using a larger task list at a given path, wi
 JSON_PATH="./path/to/your.json" cargo run --release --example ollama
 ```
 
-## Styling
+#### Styling
 
 Lint and format with:
 

--- a/compose.yml
+++ b/compose.yml
@@ -18,7 +18,7 @@ services:
   compute:
     build: "./" # TODO: use image from registry
     env_file:
-      - .env
+      - .env.compose
     environment:
       WAKU_URL: "http://host.docker.internal:8645"
       OLLAMA_HOST: "http://host.docker.internal"
@@ -27,9 +27,6 @@ services:
       RUST_LOG: "${RUST_LOGS:-info}"
       SEARCH_AGENT_URL: "http://host.docker.internal:5000"
       SEARCH_AGENT_MANAGER: true
-      DKN_TASKS: "${DKN_TASKS}"
-      DKN_SYNTHESIS_MODEL_PROVIDER: "${DKN_SYNTHESIS_MODEL_PROVIDER}"
-      DKN_SYNTHESIS_MODEL_NAME: "${DKN_SYNTHESIS_MODEL_NAME}"
     depends_on:
       - nwaku # TODO: in the future we may run Waku with a different compose, so this can be removed at that step
 

--- a/compose.yml
+++ b/compose.yml
@@ -121,7 +121,7 @@ services:
   search-agent:
     image: firstbatch/dria-searching-agent:latest
     ports:
-      - 5000:5000
+      - 5059:5000
     environment:
       AGENT_MODEL_PROVIDER: ${AGENT_MODEL_PROVIDER-Ollama}
       AGENT_MODEL: ${AGENT_MODEL:-phi3}

--- a/waku/register_rln.sh
+++ b/waku/register_rln.sh
@@ -6,7 +6,7 @@ if test -f $(pwd)/keystore/keystore.json; then
   exit 1
 fi
 
-if test -f .env; then
+if test -f $(pwd)/../.env; then
   echo "Using .env file"  
   . $(pwd)/../.env
 fi


### PR DESCRIPTION
some improvments and refactors on `search.sh`
* Load `.env` file at the start as base environment
* Update env-vars during script execution
* Write final env-vars to `.env.compose` as final environment
* Env vars contextually seperated into waku, dkn and ollama

compose updates:
* Load environment from `.compose.env`
* search agent port mapping

readme updates and small fixes
