### PR TITLE
`AvailableNodes` logic, handler refactors, workflows re-export

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,12 @@
 ## DRIA (required) ##
-# Secret key of your compute node (32 byte, hexadecimal, without 0x prefix).
-# e.g.: DKN_WALLET_SECRET_KEY=ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+# Secret key of your compute node, 32 byte in hexadecimal.
+# e.g.: DKN_WALLET_SECRET_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 DKN_WALLET_SECRET_KEY=
-# model1,model2,model3,... (comma separated, case-insensitive)
-DKN_MODELS=phi3:3.8b
-# Public key of Dria Admin node (33-byte compressed, hexadecimal, without 0x prefix).
+# Public key of Dria Admin node, 33-byte (compressed) in hexadecimal.
 # You don't need to change this, simply copy and paste it.
 DKN_ADMIN_PUBLIC_KEY=0208ef5e65a9c656a6f92fb2c770d5d5e2ecffe02a6aade19207f75110be6ae658
+# model1,model2,model3,... (comma separated, case-insensitive)
+DKN_MODELS=phi3:3.8b
 
 ## DRIA (optional) ##
 # info | debug | error | none,dkn_compute=debug
@@ -22,7 +22,7 @@ DKN_BOOTSTRAP_NODES=
 OPENAI_API_KEY=
 
 ## Ollama (if used, optional) ##
-# do not change the host, it is used by Docker
+# do not change this, it is used by Docker
 OLLAMA_HOST=http://host.docker.internal
 # you can change the port if you would like
 OLLAMA_PORT=11434

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-compute"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1125,11 +1125,11 @@ dependencies = [
  "libp2p-identity",
  "libsecp256k1",
  "log",
- "ollama-rs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ollama-workflows",
  "parking_lot",
  "public-ip",
  "rand 0.8.5",
+ "reqwest 0.12.5",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -2131,6 +2131,7 @@ dependencies = [
  "tokio 1.38.0",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3587,21 +3588,7 @@ dependencies = [
 [[package]]
 name = "ollama-rs"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255252ec57e13d2d6ae074c7b7cd8c004d17dafb1e03f954ba2fd5cc226f8f49"
-dependencies = [
- "async-trait",
- "log",
- "reqwest 0.12.5",
- "serde",
- "serde_json",
- "url",
-]
-
-[[package]]
-name = "ollama-rs"
-version = "0.2.0"
-source = "git+https://github.com/andthattoo/ollama-rs?branch=master#dcdfc07a0974f414b3a86c9aed17d43f1bba7bd1"
+source = "git+https://github.com/andthattoo/ollama-rs?rev=e566515#e56651586c468546a46a995e3176539396d85243"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3618,7 +3605,7 @@ dependencies = [
 [[package]]
 name = "ollama-workflows"
 version = "0.1.0"
-source = "git+https://github.com/andthattoo/ollama-workflows?rev=274b26e#274b26e4fe39770d8211cc4da96182f59a84dd05"
+source = "git+https://github.com/andthattoo/ollama-workflows?rev=25467d2#25467d2567db2fa1b8ebf3f96930406217f4f490"
 dependencies = [
  "async-trait",
  "colored",
@@ -3627,7 +3614,7 @@ dependencies = [
  "html2text",
  "langchain-rust",
  "log",
- "ollama-rs 0.2.0 (git+https://github.com/andthattoo/ollama-rs?branch=master)",
+ "ollama-rs",
  "openai_dive",
  "parking_lot",
  "rand 0.8.5",
@@ -4511,6 +4498,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
  "winreg 0.52.0",
 ]
 
@@ -5967,6 +5955,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkn-compute"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
@@ -12,6 +12,7 @@ parking_lot = "0.12.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1.81"
+reqwest = "0.12.5"
 
 # utilities
 base64 = "0.22.0"
@@ -34,8 +35,7 @@ sha3 = "0.10.8"
 fastbloom-rs = "0.5.9"
 
 # workflows
-ollama-workflows = { git = "https://github.com/andthattoo/ollama-workflows", rev = "274b26e" }
-ollama-rs = "0.2.0"
+ollama-workflows = { git = "https://github.com/andthattoo/ollama-workflows", rev = "25467d2" }
 
 # peer-to-peer
 libp2p = { version = "0.53", features = [

--- a/compose.yml
+++ b/compose.yml
@@ -16,7 +16,7 @@ services:
       JINA_API_KEY: ${JINA_API_KEY}
       OLLAMA_HOST: ${OLLAMA_HOST}
       OLLAMA_PORT: ${OLLAMA_PORT}
-      OLLAMA_AUTO_PULL: ${OLLAMA_AUTO_PULL}
+      OLLAMA_AUTO_PULL: ${OLLAMA_AUTO_PULL:-true}
     network_mode: "host"
     extra_hosts:
       # for Linux, we need to add this line manually

--- a/examples/common/ollama.rs
+++ b/examples/common/ollama.rs
@@ -1,6 +1,6 @@
 use std::time::SystemTime;
 
-use ollama_rs::{
+use ollama_workflows::ollama_rs::{
     generation::completion::{request::GenerationRequest, GenerationResponse},
     Ollama,
 };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -37,8 +37,8 @@ impl DriaComputeNodeConfig {
     pub fn new() -> Self {
         let secret_key = match env::var("DKN_WALLET_SECRET_KEY") {
             Ok(secret_env) => {
-                let secret_dec =
-                    hex::decode(secret_env).expect("Secret key should be 32-bytes hex encoded.");
+                let secret_dec = hex::decode(secret_env.trim_start_matches("0x"))
+                    .expect("Secret key should be 32-bytes hex encoded.");
                 SecretKey::parse_slice(&secret_dec).expect("Secret key should be parseable.")
             }
             Err(err) => {
@@ -60,7 +60,7 @@ impl DriaComputeNodeConfig {
 
         let admin_public_key = match env::var("DKN_ADMIN_PUBLIC_KEY") {
             Ok(admin_public_key) => {
-                let pubkey_dec = hex::decode(admin_public_key)
+                let pubkey_dec = hex::decode(admin_public_key.trim_start_matches("0x"))
                     .expect("Admin public key should be 33-bytes hex encoded.");
                 PublicKey::parse_slice(&pubkey_dec, None)
                     .expect("Admin public key should be parseable.")

--- a/src/config/ollama.rs
+++ b/src/config/ollama.rs
@@ -1,4 +1,4 @@
-use ollama_rs::Ollama;
+use ollama_workflows::ollama_rs::Ollama;
 
 const DEFAULT_OLLAMA_HOST: &str = "http://127.0.0.1";
 const DEFAULT_OLLAMA_PORT: u16 = 11434;

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -1,4 +1,4 @@
-use ollama_rs::error::OllamaError;
+use ollama_workflows::ollama_rs::error::OllamaError;
 
 /// Alias for `Result<T, NodeError>`.
 pub type NodeResult<T> = std::result::Result<T, NodeError>;
@@ -92,6 +92,15 @@ impl From<libp2p::gossipsub::SubscriptionError> for NodeError {
         Self {
             message: value.to_string(),
             source: "gossipsub::subscription".to_string(),
+        }
+    }
+}
+
+impl From<reqwest::Error> for NodeError {
+    fn from(value: reqwest::Error) -> Self {
+        Self {
+            message: value.to_string(),
+            source: "reqwest".to_string(),
         }
     }
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,5 +1,19 @@
+use async_trait::async_trait;
+use libp2p::gossipsub::MessageAcceptance;
+
 mod pingpong;
-pub use pingpong::HandlesPingpong;
+pub use pingpong::PingpongHandler;
 
 mod workflow;
-pub use workflow::HandlesWorkflow;
+pub use workflow::WorkflowHandler;
+
+use crate::{errors::NodeResult, p2p::P2PMessage, DriaComputeNode};
+
+#[async_trait]
+pub trait ComputeHandler {
+    async fn handle_compute(
+        node: &mut DriaComputeNode,
+        message: P2PMessage,
+        result_topic: &str,
+    ) -> NodeResult<MessageAcceptance>;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     config.check_services().await?;
 
     // launch the node
-    let mut node = DriaComputeNode::new(config, CancellationToken::new())?;
+    let mut node = DriaComputeNode::new(config, CancellationToken::new()).await?;
     node.launch().await?;
 
     Ok(())

--- a/src/p2p/available_nodes.rs
+++ b/src/p2p/available_nodes.rs
@@ -1,0 +1,147 @@
+use libp2p::{Multiaddr, PeerId};
+use std::{fmt::Debug, str::FromStr};
+
+use crate::utils::split_comma_separated;
+
+/// Static bootstrap nodes for the Kademlia DHT bootstrap step.
+const STATIC_BOOTSTRAP_NODES: [&str; 4] = [
+    "/ip4/44.206.245.139/tcp/4001/p2p/16Uiu2HAm4q3LZU2T9kgjKK4ysy6KZYKLq8KiXQyae4RHdF7uqSt4",
+    "/ip4/18.234.39.91/tcp/4001/p2p/16Uiu2HAmJqegPzwuGKWzmb5m3RdSUJ7NhEGWB5jNCd3ca9zdQ9dU",
+    "/ip4/54.242.44.217/tcp/4001/p2p/16Uiu2HAmR2sAoh9F8jT9AZup9y79Mi6NEFVUbwRvahqtWamfabkz",
+    "/ip4/52.201.242.227/tcp/4001/p2p/16Uiu2HAmFEUCy1s1gjyHfc8jey4Wd9i5bSDnyFDbWTnbrF2J3KFb",
+];
+
+/// Static relay nodes for the `P2pCircuit`.
+const STATIC_RELAY_NODES: [&str; 4] = [
+    "/ip4/34.201.33.141/tcp/4001/p2p/16Uiu2HAkuXiV2CQkC9eJgU6cMnJ9SMARa85FZ6miTkvn5fuHNufa",
+    "/ip4/18.232.93.227/tcp/4001/p2p/16Uiu2HAmHeGKhWkXTweHJTA97qwP81ww1W2ntGaebeZ25ikDhd4z",
+    "/ip4/54.157.219.194/tcp/4001/p2p/16Uiu2HAm7A5QVSy5FwrXAJdNNsdfNAcaYahEavyjnFouaEi22dcq",
+    "/ip4/54.88.171.104/tcp/4001/p2p/16Uiu2HAm5WP1J6bZC3aHxd7XCUumMt9txAystmbZSaMS2omHepXa",
+];
+
+/// Static RPC Peer IDs for the Admin RPC.
+const STATIC_RPC_PEER_IDS: [&str; 0] = [];
+
+/// API URL for refreshing the Admin RPC PeerIDs from Dria server.
+const RPC_PEER_ID_REFRESH_API_URL: &str = "https://dkn.dria.co/available-nodes";
+
+#[derive(serde::Deserialize, Debug)]
+pub struct AvailableNodesApiResponse {
+    pub bootstraps: Vec<String>,
+    pub relays: Vec<String>,
+    pub rpcs: Vec<String>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct AvailableNodes {
+    pub bootstrap_nodes: Vec<Multiaddr>,
+    pub relay_nodes: Vec<Multiaddr>,
+    pub rpc_nodes: Vec<PeerId>,
+}
+
+impl AvailableNodes {
+    /// Parses static bootstrap & relay nodes from environment variables.
+    ///
+    /// The environment variables are:
+    /// - `DRIA_BOOTSTRAP_NODES`: comma-separated list of bootstrap nodes
+    /// - `DRIA_RELAY_NODES`: comma-separated list of relay nodes
+    pub fn new_from_env() -> Self {
+        // parse bootstrap nodes
+        let bootstrap_nodes = split_comma_separated(std::env::var("DKN_BOOTSTRAP_NODES").ok());
+        if bootstrap_nodes.is_empty() {
+            log::debug!("No additional bootstrap nodes provided.");
+        } else {
+            log::debug!("Using additional bootstrap nodes: {:#?}", bootstrap_nodes);
+        }
+
+        // parse relay nodes
+        let relay_nodes = split_comma_separated(std::env::var("DKN_RELAY_NODES").ok());
+        if relay_nodes.is_empty() {
+            log::debug!("No additional relay nodes provided.");
+        } else {
+            log::debug!("Using additional relay nodes: {:#?}", relay_nodes);
+        }
+
+        Self {
+            bootstrap_nodes: parse_vec(bootstrap_nodes),
+            relay_nodes: parse_vec(relay_nodes),
+            rpc_nodes: vec![],
+        }
+    }
+
+    pub fn new_from_statics() -> Self {
+        Self {
+            bootstrap_nodes: parse_vec(STATIC_BOOTSTRAP_NODES.to_vec()),
+            relay_nodes: parse_vec(STATIC_RELAY_NODES.to_vec()),
+            rpc_nodes: parse_vec(STATIC_RPC_PEER_IDS.to_vec()),
+        }
+    }
+
+    /// Joins the available nodes from another `AvailableNodes` struct.
+    pub fn join(mut self, other: Self) -> Self {
+        self.bootstrap_nodes.extend(other.bootstrap_nodes);
+        self.relay_nodes.extend(other.relay_nodes);
+        self.rpc_nodes.extend(other.rpc_nodes);
+
+        self
+    }
+
+    /// Removes duplicates within all fields.
+    pub fn sort_dedup(mut self) -> Self {
+        self.bootstrap_nodes.sort_unstable();
+        self.bootstrap_nodes.dedup();
+
+        self.relay_nodes.sort_unstable();
+        self.relay_nodes.dedup();
+
+        self.rpc_nodes.sort_unstable();
+        self.rpc_nodes.dedup();
+
+        self
+    }
+
+    /// Refreshes the available nodes for Bootstrap, Relay and RPC nodes.
+    ///
+    /// Returns immediately if its too early to do that.
+    pub async fn get_available_nodes() -> Result<Self, reqwest::Error> {
+        let response = reqwest::get(RPC_PEER_ID_REFRESH_API_URL).await?;
+        let response_body = response.json::<AvailableNodesApiResponse>().await?;
+
+        Ok(Self {
+            bootstrap_nodes: parse_vec(response_body.bootstraps),
+            relay_nodes: parse_vec(response_body.relays),
+            rpc_nodes: parse_vec(response_body.rpcs),
+        })
+    }
+}
+
+/// Like `parse` of `str` but for vectors.
+fn parse_vec<T>(input: Vec<impl AsRef<str> + Debug>) -> Vec<T>
+where
+    T: FromStr,
+{
+    let parsed = input
+        .iter()
+        .filter_map(|s| s.as_ref().parse::<T>().ok())
+        .collect::<Vec<_>>();
+
+    if parsed.len() != input.len() {
+        log::warn!("Some inputs could not be parsed: {:?}", input);
+    }
+    parsed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[ignore = "run this manually"]
+    async fn test_get_available_nodes() {
+        std::env::set_var("RUST_LOG", "info");
+        let _ = env_logger::try_init();
+
+        let available_nodes = AvailableNodes::get_available_nodes().await.unwrap();
+        println!("{:#?}", available_nodes);
+    }
+}

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -9,3 +9,6 @@ pub use client::P2PClient;
 
 mod message;
 pub use message::P2PMessage;
+
+mod available_nodes;
+pub use available_nodes::AvailableNodes;

--- a/tests/ollama_test.rs
+++ b/tests/ollama_test.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
 
-use ollama_rs::{generation::completion::request::GenerationRequest, Ollama};
+use ollama_workflows::ollama_rs::{generation::completion::request::GenerationRequest, Ollama};
 use ollama_workflows::{Entry, Executor, Model, ProgramMemory, Workflow};
 use std::env;
 use tokio_util::sync::CancellationToken;


### PR DESCRIPTION
- `AvailableNodes` added, which is created from static & env nodes and is populated by API calls as well.
- Available nodes are updated every now and then.
- RPC check added for message validation, Origin must be an RPC peer id.
- Handler refactors
- Updated ollama workflows, uses ollama-rs re-export from it now
- Now allows `0x` in private key & admin public key env variables
- Bump patch version