### PR TITLE
Fixed cancellation signal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub(crate) mod utils;
 
 /// Crate version of the compute node.
 /// This value is attached within the published messages.
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const DRIA_COMPUTE_NODE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub use config::DriaComputeNodeConfig;
 pub use node::DriaComputeNode;

--- a/src/p2p/message.rs
+++ b/src/p2p/message.rs
@@ -39,7 +39,7 @@ impl P2PMessage {
         Self {
             payload: BASE64_STANDARD.encode(payload),
             topic: topic.to_string(),
-            version: crate::VERSION.to_string(),
+            version: crate::DRIA_COMPUTE_NODE_VERSION.to_string(),
             timestamp: get_current_time_nanos(),
         }
     }
@@ -197,7 +197,7 @@ mod tests {
             "{\"hello\":\"world\"}"
         );
         assert_eq!(message.topic, "test-topic");
-        assert_eq!(message.version, crate::VERSION);
+        assert_eq!(message.version, crate::DRIA_COMPUTE_NODE_VERSION);
         assert!(message.timestamp > 0);
 
         let parsed_body = message.parse_payload(false).expect("Should decode");
@@ -224,7 +224,7 @@ mod tests {
             "{\"hello\":\"world\"}"
         );
         assert_eq!(message.topic, "test-topic");
-        assert_eq!(message.version, crate::VERSION);
+        assert_eq!(message.version, crate::DRIA_COMPUTE_NODE_VERSION);
         assert!(message.timestamp > 0);
 
         assert!(message.is_signed(&pk).expect("Should check signature"));


### PR DESCRIPTION
- Resolves #72 
- The error was not within the Workflows repo, but instead the `tokio::select!` itself had a bug, the sigint/sigterm signal should have been caught at the topmost level in its own thread, as is happening right now.