### PR TITLE
use observed_addr, rfk cancellations, smol fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ dependencies = [
  "backoff",
  "base64 0.22.1",
  "bytes 1.7.1",
- "derive_builder 0.20.0",
+ "derive_builder",
  "eventsource-stream",
  "futures",
  "rand 0.8.5",
@@ -855,36 +855,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
-dependencies = [
- "darling_core 0.10.2",
- "darling_macro 0.10.2",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core 0.20.10",
- "darling_macro 0.20.10",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.9.3",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -897,19 +873,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.74",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
-dependencies = [
- "darling_core 0.10.2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -918,7 +883,7 @@ version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core 0.20.10",
+ "darling_core",
  "quote",
  "syn 2.0.74",
 ]
@@ -984,19 +949,6 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
-dependencies = [
- "darling 0.10.2",
- "derive_builder_core 0.9.0",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
@@ -1006,23 +958,11 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_core"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
-dependencies = [
- "darling 0.10.2",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_core"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
 dependencies = [
- "darling 0.20.10",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.74",
@@ -1034,7 +974,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
 dependencies = [
- "derive_builder_core 0.20.0",
+ "derive_builder_core",
  "syn 2.0.74",
 ]
 
@@ -1112,7 +1052,6 @@ dependencies = [
  "log",
  "ollama-workflows",
  "parking_lot",
- "public-ip",
  "rand 0.8.5",
  "reqwest 0.12.5",
  "serde",
@@ -1126,18 +1065,6 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
-]
-
-[[package]]
-name = "dns-lookup"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "socket2 0.4.10",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1229,24 +1156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570d109b813e904becc80d8d5da38376818a143348413f7149f1340fe04754d4"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1797,7 +1706,7 @@ dependencies = [
  "async-trait",
  "cfg-if 1.0.0",
  "data-encoding",
- "enum-as-inner 0.6.0",
+ "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
@@ -2127,20 +2036,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-system-resolver"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eea26c5d0b6ab9d72219f65000af310f042a740926f7b2fa3553e774036e2e7"
-dependencies = [
- "derive_builder 0.9.0",
- "dns-lookup",
- "hyper 0.14.30",
- "tokio 1.39.2",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "hyper-tls"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,17 +2125,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -3449,15 +3333,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3582,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "ollama-workflows"
 version = "0.1.0"
-source = "git+https://github.com/andthattoo/ollama-workflows?rev=25467d2#25467d2567db2fa1b8ebf3f96930406217f4f490"
+source = "git+https://github.com/andthattoo/ollama-workflows?rev=d6b2e1e#d6b2e1e0259958bd4abe301f5c6c79b7c07b1dc2"
 dependencies = [
  "async-trait",
  "colored",
@@ -3626,7 +3501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf3d3fe8284533a78c1ab1cf7da0a682f6738c621a3639e55a6e8041901b151a"
 dependencies = [
  "bytes 1.7.1",
- "derive_builder 0.20.0",
+ "derive_builder",
  "reqwest 0.12.5",
  "serde",
  "serde_json",
@@ -4040,27 +3915,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "public-ip"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4c40db5262d93298c363a299f8bc1b3a956a78eecddba3bc0e58b76e2f419a"
-dependencies = [
- "dns-lookup",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.30",
- "hyper-system-resolver",
- "pin-project-lite 0.2.14",
- "thiserror",
- "tokio 1.39.2",
- "tracing",
- "tracing-futures",
- "trust-dns-client",
- "trust-dns-proto",
-]
-
-[[package]]
 name = "pulldown-cmark"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4154,16 +4008,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
 ]
 
 [[package]]
@@ -5033,16 +4877,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
@@ -5110,12 +4944,6 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "strsim"
@@ -5560,8 +5388,6 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "futures",
- "futures-task",
  "pin-project",
  "tracing",
 ]
@@ -5593,51 +5419,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "trust-dns-client"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4ef9b9bde0559b78a4abb00339143750085f05e5a453efb7b8bef1061f09dc"
-dependencies = [
- "cfg-if 1.0.0",
- "data-encoding",
- "futures-channel",
- "futures-util",
- "lazy_static",
- "log",
- "radix_trie",
- "rand 0.8.5",
- "thiserror",
- "time 0.3.36",
- "tokio 1.39.2",
- "trust-dns-proto",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca94d4e9feb6a181c690c4040d7a24ef34018d8313ac5044a61d21222ae24e31"
-dependencies = [
- "async-trait",
- "cfg-if 1.0.0",
- "data-encoding",
- "enum-as-inner 0.3.4",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.2.3",
- "ipnet",
- "lazy_static",
- "log",
- "rand 0.8.5",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio 1.39.2",
- "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,6 +1054,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "reqwest 0.12.5",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.10.8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-compute"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ libp2p = { git = "https://github.com/anilaltuner/rust-libp2p.git", rev = "be2ed5
 libp2p-identity = { version = "0.2.9", features = ["secp256k1"] }
 tracing = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+semver = "1.0.23"
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ ollama-workflows = { git = "https://github.com/andthattoo/ollama-workflows", rev
 
 # peer-to-peer
 libp2p = { git = "https://github.com/anilaltuner/rust-libp2p.git", rev = "be2ed55", features = [
+    # libp2p = { version = "0.54.1", features = [
     "dcutr",
     "ping",
     "relay",
@@ -64,7 +65,7 @@ libp2p = { git = "https://github.com/anilaltuner/rust-libp2p.git", rev = "be2ed5
     "kad",
 ] }
 
-libp2p-identity = { version = "0.2.9", features = ["secp256k1", "ed25519"] }
+libp2p-identity = { version = "0.2.9", features = ["secp256k1"] }
 tracing = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 inherits = "release"
 debug = true
 
+[features]
+profiling = []
+
 [dependencies]
 tokio-util = { version = "0.7.10", features = ["rt"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
@@ -41,7 +44,7 @@ sha3 = "0.10.8"
 fastbloom-rs = "0.5.9"
 
 # workflows
-ollama-workflows = { git = "https://github.com/andthattoo/ollama-workflows", rev = "25467d2" }
+ollama-workflows = { git = "https://github.com/andthattoo/ollama-workflows", rev = "d6b2e1e" }
 
 # peer-to-peer
 libp2p = { git = "https://github.com/anilaltuner/rust-libp2p.git", rev = "be2ed55", features = [
@@ -64,7 +67,6 @@ libp2p = { git = "https://github.com/anilaltuner/rust-libp2p.git", rev = "be2ed5
 libp2p-identity = { version = "0.2.9", features = ["secp256k1", "ed25519"] }
 tracing = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-public-ip = "0.2.2"
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkn-compute"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
@@ -31,6 +31,7 @@ url = "2.5.0"
 urlencoding = "2.1.3"
 uuid = { version = "1.8.0", features = ["v4"] }
 rand = "0.8.5"
+semver = "1.0.23"
 
 # logging
 env_logger = "0.11.3"
@@ -64,11 +65,9 @@ libp2p = { git = "https://github.com/anilaltuner/rust-libp2p.git", rev = "be2ed5
     "quic",
     "kad",
 ] }
-
 libp2p-identity = { version = "0.2.9", features = ["secp256k1"] }
 tracing = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-semver = "1.0.23"
 
 
 [dev-dependencies]

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,13 @@ trace:
 build:
 		cargo build
 
-.PHONY: profile #      | Profile with flamegraph at dev level
-profile:
-	  cargo flamegraph --root --profile=profiling
+.PHONY: profile-cpu #   | Profile CPU usage with flamegraph
+profile-cpu:
+	  cargo flamegraph --root --profile=profiling --features=profiling
+
+.PHONY: profile-mem #   | Profile memory usage with instruments
+profile-mem:
+	  cargo instruments --profile=profiling --features=profiling -t Leaks
 
 .PHONY: version #      | Print version
 version:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ debug:
 
 .PHONY: trace #        | Run with crate-level TRACE logging
 trace:
-		RUST_LOG=none,dkn_compute=trace cargo run
+		RUST_LOG=none,dkn_compute=trace,libp2p=debug cargo run
 
 .PHONY: build #        | Build
 build:

--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@
 
 ## About
 
-A **Dria Compute Node** is a unit of computation within the Dria Knowledge Network. It's purpose is to process tasks given by the **Dria Admin Node**, and receive rewards for providing correct results.
-
-To get started, [setup](#setup) your envrionment and then see [usage](#usage) to run the node.
+A **Dria Compute Node** is a unit of computation within the Dria Knowledge Network. It's purpose is to process tasks given by the **Dria Admin Node**. To get started, [setup](#setup) your envrionment and then see [usage](#usage) to run the node.
 
 ### Tasks
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ Based on the resources of your machine, you must decide which models that you wi
 - `phi3:14b-medium-128k-instruct-q4_1`
 - `phi3:3.8b`
 - `llama3.1:latest`
+- `phi3.5:3.8b`
+- `phi3.5:3.8b-mini-instruct-fp16`
 
 #### OpenAI Models
 
@@ -338,17 +340,21 @@ make format # rustfmt
 
 ### Profiling
 
-To create a flamegraph of the application, do:
+We would like to profile both CPU and Memory usage.
+
+To create a [flamegraph](https://crates.io/crates/flamegraph) of the application, do:
 
 ```sh
-make profile
+make profile-cpu
 ```
 
 This will create a profiling build that inherits `release` mode, except with debug information.
 
+To profile memory usage, we make use of [cargo-instruments](https://crates.io/crates/cargo-instruments).
+
 > [!NOTE]
 >
-> Profiling requires superuser access.
+> CPU profiling may require super-user access.
 
 ## License
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,19 +1,22 @@
 services:
   # Compute Node
   compute:
-    image: "firstbatch/dkn-compute-node:latest"
-    # build: "./" # use this one instead if you want to build locally
+    # image: "firstbatch/dkn-compute-node:latest"
+    build: "./" # use this one instead if you want to build locally
     environment:
+      # Dria
       DKN_WALLET_SECRET_KEY: ${DKN_WALLET_SECRET_KEY}
       DKN_ADMIN_PUBLIC_KEY: ${DKN_ADMIN_PUBLIC_KEY}
       DKN_MODELS: ${DKN_MODELS}
-      RUST_LOG: ${RUST_LOG-none,dkn_compute=info}
       DKN_P2P_LISTEN_ADDR: ${DKN_P2P_LISTEN_ADDR}
       DKN_RELAY_NODES: ${DKN_RELAY_NODES}
       DKN_BOOTSTRAP_NODES: ${DKN_BOOTSTRAP_NODES}
+      RUST_LOG: ${RUST_LOG:-none,dkn_compute=info}
+      # Api Keys
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       SERPER_API_KEY: ${SERPER_API_KEY}
       JINA_API_KEY: ${JINA_API_KEY}
+      # Ollama
       OLLAMA_HOST: ${OLLAMA_HOST}
       OLLAMA_PORT: ${OLLAMA_PORT}
       OLLAMA_AUTO_PULL: ${OLLAMA_AUTO_PULL:-true}

--- a/compose.yml
+++ b/compose.yml
@@ -4,6 +4,7 @@ services:
     # image: "firstbatch/dkn-compute-node:latest"
     build: "./" # use this one instead if you want to build locally
     environment:
+      RUST_LOG: ${RUST_LOG:-none,dkn_compute=info}
       # Dria
       DKN_WALLET_SECRET_KEY: ${DKN_WALLET_SECRET_KEY}
       DKN_ADMIN_PUBLIC_KEY: ${DKN_ADMIN_PUBLIC_KEY}
@@ -11,7 +12,6 @@ services:
       DKN_P2P_LISTEN_ADDR: ${DKN_P2P_LISTEN_ADDR}
       DKN_RELAY_NODES: ${DKN_RELAY_NODES}
       DKN_BOOTSTRAP_NODES: ${DKN_BOOTSTRAP_NODES}
-      RUST_LOG: ${RUST_LOG:-none,dkn_compute=info}
       # Api Keys
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       SERPER_API_KEY: ${SERPER_API_KEY}

--- a/compose.yml
+++ b/compose.yml
@@ -1,8 +1,8 @@
 services:
   # Compute Node
   compute:
-    # image: "firstbatch/dkn-compute-node:latest"
-    build: "./" # use this one instead if you want to build locally
+    image: "firstbatch/dkn-compute-node:latest"
+    # build: "./" # use this one instead if you want to build locally
     environment:
       RUST_LOG: ${RUST_LOG:-none,dkn_compute=info}
       # Dria

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -38,6 +38,7 @@ impl ModelConfig {
         Self { models }
     }
 
+    /// Returns the models that belong to a given providers from the config.
     pub fn get_models_for_provider(&self, provider: ModelProvider) -> Vec<Model> {
         self.models
             .iter()

--- a/src/config/ollama.rs
+++ b/src/config/ollama.rs
@@ -1,4 +1,6 @@
-use ollama_workflows::ollama_rs::Ollama;
+use std::time::Duration;
+
+use ollama_workflows::{ollama_rs::Ollama, Executor, Model, ProgramMemory, Workflow};
 
 const DEFAULT_OLLAMA_HOST: &str = "http://127.0.0.1";
 const DEFAULT_OLLAMA_PORT: u16 = 11434;
@@ -46,12 +48,11 @@ impl OllamaConfig {
             .unwrap_or(DEFAULT_OLLAMA_PORT);
 
         // Ollama workflows may require specific models to be loaded regardless of the choices
-        let hardcoded_models = HARDCODED_MODELS
-            .into_iter()
-            .map(|s| s.to_string())
-            .collect();
+        let hardcoded_models = HARDCODED_MODELS.iter().map(|s| s.to_string()).collect();
 
-        let auto_pull = std::env::var("OLLAMA_AUTO_PULL").unwrap_or_default() == "true";
+        let auto_pull = std::env::var("OLLAMA_AUTO_PULL")
+            .map(|s| s == "true")
+            .unwrap_or_default();
 
         Self {
             host,
@@ -61,18 +62,19 @@ impl OllamaConfig {
         }
     }
 
-    /// Check if requested models exist.
-    pub async fn check(&self, external_models: Vec<String>) -> Result<(), String> {
+    /// Check if requested models exist in Ollama, and then tests them using a workflow.
+    pub async fn check(
+        &self,
+        external_models: Vec<Model>,
+        test_workflow_timeout: Duration,
+    ) -> Result<Vec<Model>, String> {
         log::info!(
-            "Checking Ollama requirements (auto-pull {})",
-            if self.auto_pull { "on" } else { "off" }
+            "Checking Ollama requirements (auto-pull {}, workflow timeout: {}s)",
+            if self.auto_pull { "on" } else { "off" },
+            test_workflow_timeout.as_secs()
         );
 
         let ollama = Ollama::new(&self.host, self.port);
-
-        // the list of required models is those given in DKN_MODELS and the hardcoded ones
-        let mut required_models = self.hardcoded_models.clone();
-        required_models.extend(external_models);
 
         // fetch local models
         let local_models = match ollama.list_local_models().await {
@@ -84,34 +86,139 @@ impl OllamaConfig {
                 }
             }
         };
+        log::info!("Found local Ollama models: {:#?}", local_models);
 
-        // check that each required model exists here
-        log::debug!("Checking required models: {:#?}", required_models);
-        log::debug!("Found local models: {:#?}", local_models);
-        for model in required_models {
-            if !local_models.iter().any(|m| *m == model) {
-                log::warn!("Model {} not found in Ollama", model);
-                if self.auto_pull {
-                    // if auto-pull is enabled, pull the model
-                    log::info!(
-                        "Downloading missing model {} (this may take a while)",
-                        model
-                    );
-                    let status = ollama
-                        .pull_model(model, false)
-                        .await
-                        .map_err(|e| format!("Error pulling model with Ollama: {}", e))?;
-                    log::debug!("Pulled model with Ollama, final status: {:#?}", status);
-                } else {
-                    // otherwise, give error
-                    log::error!("Please download it with: ollama pull {}", model);
-                    log::error!("Or, set OLLAMA_AUTO_PULL=true to pull automatically.");
-                    return Err("Required model not pulled in Ollama.".into());
-                }
+        // check hardcoded models & pull them if available
+        // these are not used directly by the user, but are needed for the workflows
+        log::debug!("Checking hardcoded models: {:#?}", self.hardcoded_models);
+        for model in &self.hardcoded_models {
+            if !local_models.contains(model) {
+                self.try_pull(&ollama, model.to_owned()).await?;
+            }
+
+            // we dont check workflows for hardcoded models
+        }
+
+        // check external models & pull them if available
+        // and also run a test workflow for them
+        let mut good_models = Vec::new();
+        for model in external_models {
+            if !local_models.contains(&model.to_string()) {
+                self.try_pull(&ollama, model.to_string()).await?;
+            }
+
+            let ok = self
+                .test_workflow(model.clone(), test_workflow_timeout)
+                .await;
+            if ok {
+                good_models.push(model);
             }
         }
 
-        log::info!("Ollama setup is all good.",);
-        Ok(())
+        log::info!(
+            "Ollama checks are finished, using models: {:#?}",
+            good_models
+        );
+        Ok(good_models)
+    }
+
+    /// Pulls a model if `auto_pull` exists, otherwise returns an error.
+    async fn try_pull(&self, ollama: &Ollama, model: String) -> Result<(), String> {
+        log::warn!("Model {} not found in Ollama", model);
+        if self.auto_pull {
+            // if auto-pull is enabled, pull the model
+            log::info!(
+                "Downloading missing model {} (this may take a while)",
+                model
+            );
+            let status = ollama
+                .pull_model(model, false)
+                .await
+                .map_err(|e| format!("Error pulling model with Ollama: {}", e))?;
+            log::debug!("Pulled model with Ollama, final status: {:#?}", status);
+            Ok(())
+        } else {
+            // otherwise, give error
+            log::error!("Please download missing model with: ollama pull {}", model);
+            log::error!("Or, set OLLAMA_AUTO_PULL=true to pull automatically.");
+            return Err("Required model not pulled in Ollama.".into());
+        }
+    }
+
+    /// Runs a small workflow to test Ollama Workflows.
+    ///
+    /// This is to see if a given system can execute Ollama workflows for their chosen models,
+    /// e.g. if they have enough RAM/CPU and such.
+    pub async fn test_workflow(&self, model: Model, timeout: Duration) -> bool {
+        // this is the test workflow that we will run
+        // TODO: when Workflow's have `Clone`, we can remove the repetitive parsing here
+        let workflow = serde_json::from_value::<Workflow>(serde_json::json!({
+            "name": "Simple",
+            "description": "This is a simple workflow",
+            "config":{
+                "max_steps": 5,
+                "max_time": 100,
+                "max_tokens": 100,
+                "tools": []
+            },
+            "tasks":[
+                {
+                    "id": "A",
+                    "name": "Random Poem",
+                    "description": "Writes a poem about Kapadokya.",
+                    "prompt": "Please write a poem about Kapadokya.",
+                    "inputs":[],
+                    "operator": "generation",
+                    "outputs":[
+                        {
+                            "type": "write",
+                            "key": "poem",
+                            "value": "__result"
+                        }
+                    ]
+                },
+                {
+                    "id": "__end",
+                    "name": "end",
+                    "description": "End of the task",
+                    "prompt": "End of the task",
+                    "inputs": [],
+                    "operator": "end",
+                    "outputs": []
+                }
+            ],
+            "steps":[
+                {
+                    "source":"A",
+                    "target":"end"
+                }
+            ],
+            "return_value":{
+                "input":{
+                    "type": "read",
+                    "key": "poem"
+                }
+            }
+        }))
+        .expect("Preset workflow should be parsed");
+
+        log::info!("Testing model {}", model);
+        let executor = Executor::new_at(model.clone(), &self.host, self.port);
+        let mut memory = ProgramMemory::new();
+        tokio::select! {
+            _ = tokio::time::sleep(timeout) => {
+                log::warn!("Ignoring model {}: Timeout", model);
+            },
+            result = executor.execute(None, workflow, &mut memory) => {
+                if result.is_empty() {
+                    log::warn!("Ignoring model {}: Empty Result", model);
+                } else {
+                    log::info!("Accepting model {}", model);
+                    return true;
+                }
+            }
+        };
+
+        return false;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub(crate) mod utils;
 
 /// Crate version of the compute node.
 /// This value is attached within the published messages.
-pub const DRIA_COMPUTE_NODE_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const DRIA_COMPUTE_NODE_VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
 pub use config::DriaComputeNodeConfig;
 pub use node::DriaComputeNode;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tokio::spawn(async move {
         #[cfg(feature = "profiling")]
         {
-            tokio::time::sleep(tokio::time::Duration::from_secs(120)).await;
+            const PROFILE_DURATION_SECS: u64 = 120;
+            tokio::time::sleep(tokio::time::Duration::from_secs(PROFILE_DURATION_SECS)).await;
             token.cancel();
         }
 
@@ -69,7 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Waits for SIGTERM or SIGINT, and cancels the given token when the signal is received.
-#[cfg(not(feature = "profiling"))]
+#[allow(unused)]
 async fn wait_for_termination(cancellation: CancellationToken) -> std::io::Result<()> {
     use tokio::signal::unix::{signal, SignalKind};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,56 +15,74 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         dkn_compute::DRIA_COMPUTE_NODE_VERSION
     );
 
-    // create configurations & check required services
-    let config = DriaComputeNodeConfig::new();
-    if let Err(err) = config.check_services().await {
-        log::error!("Error checking services: {}", err);
-        panic!("Service check failed.")
-    }
-
     let token = CancellationToken::new();
-
-    // launch the node
-    let node_token = token.clone();
-    let node_handle = tokio::spawn(async move {
-        match DriaComputeNode::new(config, node_token).await {
-            Ok(mut node) => {
-                if let Err(err) = node.launch().await {
-                    log::error!("Node launch error: {}", err);
-                    panic!("Node failed.")
-                };
-            }
-            Err(err) => {
-                log::error!("Node setup error: {}", err);
-                panic!("Could not setup node.")
-            }
-        }
-    });
-
-    // TODO: add auto-cancel for profiling
-
+    let cancellation_token = token.clone();
     // add cancellation check
     tokio::spawn(async move {
         #[cfg(feature = "profiling")]
         {
             const PROFILE_DURATION_SECS: u64 = 120;
             tokio::time::sleep(tokio::time::Duration::from_secs(PROFILE_DURATION_SECS)).await;
-            token.cancel();
+            cancellation_token.cancel();
         }
 
         #[cfg(not(feature = "profiling"))]
-        if let Err(err) = wait_for_termination(token.clone()).await {
+        if let Err(err) = wait_for_termination(cancellation_token.clone()).await {
             log::error!("Error waiting for termination: {}", err);
             log::error!("Cancelling due to unexpected error.");
-            token.cancel();
+            cancellation_token.cancel();
         };
     });
 
-    // wait for tasks to complete
-    if let Err(err) = node_handle.await {
-        log::error!("Node handle error: {}", err);
-        panic!("Could not exit Node thread handle.");
+    // create configurations & check required services
+    let config = DriaComputeNodeConfig::new();
+    let service_check_token = token.clone();
+    let mut config_clone = config.clone();
+    let service_check_handle = tokio::spawn(async move {
+        tokio::select! {
+            _ = service_check_token.cancelled() => {
+                log::info!("Service check cancelled.");
+                return;
+            }
+            result = config_clone.check_services() => {
+                if let Err(err) = result {
+                    log::error!("Error checking services: {}", err);
+                    panic!("Service check failed.")
+                }
+            }
+        }
+    });
+
+    // wait for service check to complete
+    if let Err(err) = service_check_handle.await {
+        log::error!("Service check handle error: {}", err);
+        panic!("Could not exit service check thread handle.");
     };
+
+    if !token.is_cancelled() {
+        // launch the node
+        let node_token = token.clone();
+        let node_handle = tokio::spawn(async move {
+            match DriaComputeNode::new(config, node_token).await {
+                Ok(mut node) => {
+                    if let Err(err) = node.launch().await {
+                        log::error!("Node launch error: {}", err);
+                        panic!("Node failed.")
+                    };
+                }
+                Err(err) => {
+                    log::error!("Node setup error: {}", err);
+                    panic!("Could not setup node.")
+                }
+            }
+        });
+
+        // wait for tasks to complete
+        if let Err(err) = node_handle.await {
+            log::error!("Node handle error: {}", err);
+            panic!("Could not exit Node thread handle.");
+        };
+    }
 
     Ok(())
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -54,7 +54,7 @@ impl DriaComputeNode {
             )
             .sort_dedup();
 
-        let p2p = P2PClient::new(keypair, listen_addr, &available_nodes, cancellation.clone())?;
+        let p2p = P2PClient::new(keypair, listen_addr, &available_nodes)?;
 
         Ok(DriaComputeNode {
             config,
@@ -187,11 +187,7 @@ impl DriaComputeNode {
                             // validate the message based on the result
                             match handle_result {
                                 Ok(acceptance) => {
-                                    log::debug!(
-                                        "Validating message ({}): {:?}",
-                                        message_id,
-                                        acceptance
-                                    );
+
                                     self.p2p.validate_message(&message_id, &peer_id, acceptance)?;
                                 },
                                 Err(err) => {

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -92,7 +92,7 @@ fn create_gossipsub_behavior(author: PeerId) -> gossipsub::Behaviour {
 
     /// We accept permissive validation mode, meaning that we accept all messages
     /// and check their fields based on whether they exist or not.
-    const VALIDATION_MODE: ValidationMode = ValidationMode::Permissive;
+    const VALIDATION_MODE: ValidationMode = ValidationMode::None;
 
     /// Gossip cache TTL in seconds
     const GOSSIP_TTL_SECS: u64 = 100;
@@ -101,7 +101,7 @@ fn create_gossipsub_behavior(author: PeerId) -> gossipsub::Behaviour {
     const MESSAGE_CAPACITY: usize = 100;
 
     /// Max transmit size for payloads 256 KB
-    const MAX_TRANSMIT_SIZE: usize = 262144;
+    const MAX_TRANSMIT_SIZE: usize = 256 << 10;
 
     /// Max IHAVE length, this is much lower than the default
     /// because we don't need historic messages at all

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -115,6 +115,8 @@ fn create_gossipsub_behavior(author: PeerId) -> gossipsub::Behaviour {
         MessageId::from(hasher.finish().to_string())
     };
 
+    // TODO: add data transform here later
+
     Behaviour::new(
         MessageAuthenticity::Author(author),
         ConfigBuilder::default()

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -6,7 +6,7 @@ use libp2p::identity::{Keypair, PublicKey};
 use libp2p::kad::store::MemoryStore;
 use libp2p::{autonat, dcutr, gossipsub, identify, kad, relay, swarm::NetworkBehaviour, PeerId};
 
-use crate::p2p::DRIA_PROTO_NAME;
+use crate::p2p::{P2P_KADEMLIA_PROTOCOL, P2P_PROTOCOL_STRING};
 
 #[derive(NetworkBehaviour)]
 pub struct DriaBehaviour {
@@ -41,7 +41,9 @@ fn create_kademlia_behavior(local_peer_id: PeerId) -> kad::Behaviour<MemoryStore
     const QUERY_TIMEOUT_SECS: u64 = 5 * 60;
     const RECORD_TTL_SECS: u64 = 30;
 
-    let mut cfg = Config::new(DRIA_PROTO_NAME);
+    // TODO: use versioning here?
+
+    let mut cfg = Config::new(P2P_KADEMLIA_PROTOCOL);
     cfg.set_query_timeout(Duration::from_secs(QUERY_TIMEOUT_SECS))
         .set_record_ttl(Some(Duration::from_secs(RECORD_TTL_SECS)));
 
@@ -53,8 +55,7 @@ fn create_kademlia_behavior(local_peer_id: PeerId) -> kad::Behaviour<MemoryStore
 fn create_identify_behavior(local_public_key: PublicKey) -> identify::Behaviour {
     use identify::{Behaviour, Config};
 
-    // TODO: can we use a different protocol version, e.g. `dria/CRATE_VERSION`
-    let cfg = Config::new(DRIA_PROTO_NAME.to_string(), local_public_key);
+    let cfg = Config::new(P2P_PROTOCOL_STRING.to_string(), local_public_key);
 
     Behaviour::new(cfg)
 }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -26,8 +26,8 @@ impl DriaBehaviour {
             relay: relay_behavior,
             gossipsub: create_gossipsub_behavior(key.clone()),
             kademlia: create_kademlia_behavior(peer_id),
-            identify: create_identify_behavior(public_key.clone()),
-            autonat: create_autonat_behavior(public_key),
+            autonat: create_autonat_behavior(peer_id),
+            identify: create_identify_behavior(public_key),
             dcutr: create_dcutr_behavior(peer_id),
         }
     }
@@ -71,11 +71,11 @@ fn create_dcutr_behavior(local_peer_id: PeerId) -> dcutr::Behaviour {
 
 /// Configures the Autonat behavior to assist in network address translation detection.
 #[inline]
-fn create_autonat_behavior(key: PublicKey) -> autonat::Behaviour {
+fn create_autonat_behavior(local_peer_id: PeerId) -> autonat::Behaviour {
     use autonat::{Behaviour, Config};
 
     Behaviour::new(
-        key.to_peer_id(),
+        local_peer_id,
         Config {
             only_global_ips: false,
             ..Default::default()

--- a/src/p2p/client.rs
+++ b/src/p2p/client.rs
@@ -75,7 +75,7 @@ impl P2PClient {
             }) {
                 log::info!("Dialling peer: {}", addr);
                 swarm.dial(addr.clone()).map_err(|e| e.to_string())?;
-                log::info!("Adding address to Kademlia routing table");
+                log::info!("Adding {} to Kademlia routing table", addr);
                 swarm
                     .behaviour_mut()
                     .kademlia
@@ -269,38 +269,16 @@ impl P2PClient {
     ) {
         match result {
             Ok(GetClosestPeersOk { peers, .. }) => {
-                if !peers.is_empty() {
-                    log::debug!(
-                        "Kademlia: Query finished with {} closest peers.",
-                        peers.len()
-                    );
-                    for peer in peers {
-                        log::debug!("Gossipsub: Adding peer {0}", peer.peer_id);
-                        self.swarm
-                            .behaviour_mut()
-                            .gossipsub
-                            .add_explicit_peer(&peer.peer_id);
-                    }
-                } else {
-                    log::warn!("Kademlia: Query finished with no closest peers.");
-                }
+                log::info!(
+                    "Kademlia: Query finished with {} closest peers.",
+                    peers.len()
+                );
             }
             Err(GetClosestPeersError::Timeout { peers, .. }) => {
-                if !peers.is_empty() {
-                    log::debug!(
-                        "Kademlia: Query timed out with {} closest peers.",
-                        peers.len()
-                    );
-                    for peer in peers {
-                        log::info!("Gossipsub: Adding peer {0}", peer.peer_id);
-                        self.swarm
-                            .behaviour_mut()
-                            .gossipsub
-                            .add_explicit_peer(&peer.peer_id);
-                    }
-                } else {
-                    log::warn!("Kademlia: Query timed out with no closest peers.");
-                }
+                log::info!(
+                    "Kademlia: Query timed out with {} closest peers.",
+                    peers.len()
+                );
             }
         }
     }

--- a/src/p2p/data_transform.rs
+++ b/src/p2p/data_transform.rs
@@ -1,0 +1,95 @@
+use libp2p::gossipsub::{DataTransform, Message, RawMessage, TopicHash};
+use std::io::{Error, ErrorKind};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A `DataTransform` implementation that adds & checks a timestamp to the message.
+pub struct TTLDataTransform {
+    /// Time-to-live, e.g. obtained from some `duration.as_secs()`.
+    ttl_secs: u64,
+}
+
+impl TTLDataTransform {
+    const MID_SIZE: usize = 8;
+
+    #[inline(always)]
+    fn get_time_secs(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+}
+
+impl DataTransform for TTLDataTransform {
+    fn inbound_transform(&self, mut raw_message: RawMessage) -> Result<Message, Error> {
+        // check length
+        if raw_message.data.len() < Self::MID_SIZE {
+            return Err(Error::new(ErrorKind::InvalidInput, "Message too short"));
+        }
+
+        // parse time
+        let raw_data = raw_message.data.split_off(Self::MID_SIZE);
+        let msg_time = u64::from_be_bytes(raw_message.data[0..Self::MID_SIZE].try_into().unwrap());
+
+        // check ttl
+        if msg_time + self.ttl_secs < self.get_time_secs() {
+            return Err(Error::new(ErrorKind::InvalidInput, "Message expired"));
+        }
+
+        Ok(Message {
+            source: raw_message.source,
+            data: raw_data,
+            sequence_number: raw_message.sequence_number,
+            topic: raw_message.topic,
+        })
+    }
+
+    fn outbound_transform(
+        &self,
+        _topic: &TopicHash,
+        data: Vec<u8>,
+    ) -> Result<Vec<u8>, std::io::Error> {
+        let msg_time = self.get_time_secs().to_be_bytes();
+
+        // prepend time bytes to the data
+        let mut transformed_data = Vec::with_capacity(Self::MID_SIZE + data.len());
+        transformed_data.extend_from_slice(&msg_time);
+        transformed_data.extend_from_slice(&data);
+
+        Ok(transformed_data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn test_ttl_data_transform() {
+        let data = vec![1, 2, 3, 4, 5];
+        let ttl_secs = Duration::from_secs(100).as_secs();
+        let ttl_data_transform = TTLDataTransform { ttl_secs };
+        let topic = TopicHash::from_raw("topic");
+
+        // outbound transform
+        let transformed_data = ttl_data_transform
+            .outbound_transform(&topic, data.clone())
+            .unwrap();
+
+        // inbound transform
+        let raw_message = RawMessage {
+            source: Default::default(),
+            data: transformed_data,
+            sequence_number: None,
+            topic,
+            signature: Default::default(),
+            key: Default::default(),
+            validated: false,
+        };
+        let message = ttl_data_transform.inbound_transform(raw_message).unwrap();
+
+        assert_eq!(message.data, data);
+    }
+}

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -1,6 +1,11 @@
 use libp2p::StreamProtocol;
 
-pub(crate) const P2P_KADEMLIA_PROTOCOL: StreamProtocol = StreamProtocol::new("/dria/kad/1.0.0");
+/// Kademlia protocol version, in the form of `/dria/kad/<version>`.
+/// Notice the `/` at the start.
+pub(crate) const P2P_KADEMLIA_PROTOCOL: StreamProtocol =
+    StreamProtocol::new(concat!("/dria/kad/", env!("CARGO_PKG_VERSION")));
+
+/// Kademlia protocol version, in the form of `dria/<version>`.
 pub(crate) const P2P_PROTOCOL_STRING: &str = concat!("dria/", env!("CARGO_PKG_VERSION"));
 
 mod behaviour;

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -1,5 +1,7 @@
 use libp2p::StreamProtocol;
-pub const DRIA_PROTO_NAME: StreamProtocol = StreamProtocol::new("/dria/kad/1.0.0");
+
+pub(crate) const P2P_KADEMLIA_PROTOCOL: StreamProtocol = StreamProtocol::new("/dria/kad/1.0.0");
+pub(crate) const P2P_PROTOCOL_STRING: &str = concat!("dria/", env!("CARGO_PKG_VERSION"));
 
 mod behaviour;
 pub use behaviour::{DriaBehaviour, DriaBehaviourEvent};
@@ -8,6 +10,7 @@ mod client;
 pub use client::P2PClient;
 
 mod message;
+
 pub use message::P2PMessage;
 
 mod available_nodes;

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -12,3 +12,5 @@ pub use message::P2PMessage;
 
 mod available_nodes;
 pub use available_nodes::AvailableNodes;
+
+mod data_transform;

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -118,4 +118,22 @@ mod tests {
             "Could not verify signature."
         );
     }
+
+    #[test]
+    fn test_memory_usage() {
+        let secret_key =
+            SecretKey::parse_slice(DUMMY_KEY).expect("Should parse private key slice.");
+        let public_key = PublicKey::from_secret_key(&secret_key);
+
+        // sign the message using the secret key
+        let digest = sha256hash(MESSAGE);
+        let message = Message::parse_slice(&digest).expect("Should parse message.");
+        let (signature, _) = sign(&message, &secret_key);
+
+        // verify signature with context
+        for _ in 0..1_000_000 {
+            let ok = verify(&message, &signature, &public_key);
+            assert!(ok);
+        }
+    }
 }


### PR DESCRIPTION
- Now `identify` uses `observed_address` instead of all addresses in a loop, this is in line with AutoNATs guide
- Logs AutoNAT status update, resolves #102
- Cancellation removed within p2pclient, as it suffices to handle it outside at top-level
- Resolves #101 
- Added `profiling` feature for auto-cancel, is needed for profiling to work nicely
- Updated Ollama workflows
- Added gossipsub data transform impl based on TTL, **not used yet though**, added its test
- Added better service checks, Ollama now runs a test workflow to test if CPU / RAM is enough. Added cancellation to this as well.
- Added kademlia and identify versioning, resolves #105 
- Removed `add_explicit_peer` lines, it is causing major bugs due to network size