### PR TITLE
update to mem fixed fork rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,7 +2366,7 @@ checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
 [[package]]
 name = "libp2p"
 version = "0.54.1"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "bytes 1.7.1",
  "either",
@@ -2402,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.4.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.13.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -2439,7 +2439,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.4.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -2450,7 +2450,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.42.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "either",
  "fnv",
@@ -2477,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dcutr"
 version = "0.12.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -2499,7 +2499,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.42.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "async-trait",
  "futures",
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.47.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "asynchronous-codec",
  "base64 0.22.1",
@@ -2545,7 +2545,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.45.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.46.1"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "arrayvec",
  "asynchronous-codec",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.46.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "data-encoding",
  "futures",
@@ -2635,7 +2635,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.14.2"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2655,7 +2655,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.45.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.7.1",
@@ -2680,7 +2680,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.45.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "either",
  "futures",
@@ -2697,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.11.1"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "bytes 1.7.1",
  "futures",
@@ -2720,7 +2720,7 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.18.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.7.1",
@@ -2744,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.27.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "async-trait",
  "futures",
@@ -2763,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.45.1"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "either",
  "fnv",
@@ -2786,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2797,7 +2797,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.42.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2813,7 +2813,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.5.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -2831,7 +2831,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.3.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2846,7 +2846,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.46.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "either",
  "futures",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "bytes 1.7.1",
  "futures",
@@ -3944,7 +3944,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.7.1",
@@ -4520,7 +4520,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=3c55e95#3c55e954856d0bb95039d04f4001d923d109e220"
 dependencies = [
  "futures",
  "pin-project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,7 +2366,7 @@ checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
 [[package]]
 name = "libp2p"
 version = "0.54.1"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "bytes 1.7.1",
  "either",
@@ -2402,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.4.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.13.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -2439,7 +2439,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.4.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -2450,7 +2450,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.42.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "either",
  "fnv",
@@ -2477,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dcutr"
 version = "0.12.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -2499,7 +2499,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.42.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "async-trait",
  "futures",
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.47.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "asynchronous-codec",
  "base64 0.22.1",
@@ -2545,7 +2545,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.45.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.46.1"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "arrayvec",
  "asynchronous-codec",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.46.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "data-encoding",
  "futures",
@@ -2635,7 +2635,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.14.2"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2655,7 +2655,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.45.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.7.1",
@@ -2680,7 +2680,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.45.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "either",
  "futures",
@@ -2697,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.11.1"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "bytes 1.7.1",
  "futures",
@@ -2720,7 +2720,7 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.18.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.7.1",
@@ -2744,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.27.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "async-trait",
  "futures",
@@ -2763,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.45.1"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "either",
  "fnv",
@@ -2786,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2797,7 +2797,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.42.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2813,7 +2813,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.5.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -2831,7 +2831,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.3.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2846,7 +2846,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.46.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "either",
  "futures",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "bytes 1.7.1",
  "futures",
@@ -3944,7 +3944,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.7.1",
@@ -4520,7 +4520,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=be2ed55#be2ed5544a5d5fbbed4b2f57600398cdebe48ca6"
+source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=62f910e#62f910e30096718d0849a3b35b062c4a9b89ab4f"
 dependencies = [
  "futures",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ fastbloom-rs = "0.5.9"
 ollama-workflows = { git = "https://github.com/andthattoo/ollama-workflows", rev = "d6b2e1e" }
 
 # peer-to-peer
-libp2p = { git = "https://github.com/anilaltuner/rust-libp2p.git", rev = "be2ed55", features = [
+libp2p = { git = "https://github.com/anilaltuner/rust-libp2p.git", rev = "62f910e", features = [
     # libp2p = { version = "0.54.1", features = [
     "dcutr",
     "ping",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ fastbloom-rs = "0.5.9"
 ollama-workflows = { git = "https://github.com/andthattoo/ollama-workflows", rev = "d6b2e1e" }
 
 # peer-to-peer
-libp2p = { git = "https://github.com/anilaltuner/rust-libp2p.git", rev = "62f910e", features = [
+libp2p = { git = "https://github.com/anilaltuner/rust-libp2p.git", rev = "3c55e95", features = [
     # libp2p = { version = "0.54.1", features = [
     "dcutr",
     "ping",

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -60,6 +60,9 @@ fn create_identify_behavior(local_public_key: PublicKey) -> identify::Behaviour 
     Behaviour::new(cfg)
 }
 
+/// Configures the Dcutr behavior to allow nodes to connect via hole-punching.
+/// It uses a Relay for the hole-punching process, and if it succeeds the peers are
+/// connected directly without the need for the relay; otherwise, they keep using the relay.
 #[inline]
 fn create_dcutr_behavior(local_peer_id: PeerId) -> dcutr::Behaviour {
     use dcutr::Behaviour;

--- a/src/p2p/client.rs
+++ b/src/p2p/client.rs
@@ -204,7 +204,7 @@ impl P2PClient {
     ///
     /// This method should be called in a loop to keep the client running.
     /// When a GossipSub message is received, it will be returned.
-    pub async fn process_events(&mut self) -> Option<(PeerId, MessageId, Message)> {
+    pub async fn process_events(&mut self) -> (PeerId, MessageId, Message) {
         loop {
             // refresh peers
             self.refresh_peer_counts().await;
@@ -227,7 +227,7 @@ impl P2PClient {
                         message,
                     },
                 )) => {
-                    return Some((peer_id, message_id, message));
+                    return (peer_id, message_id, message);
                 }
                 SwarmEvent::Behaviour(DriaBehaviourEvent::Autonat(
                     autonat::Event::StatusChanged { old, new },
@@ -326,7 +326,7 @@ impl P2PClient {
     /// Should be called in a loop.
     ///
     /// Returns: (All Peer Count, Mesh Peer Count)
-    async fn refresh_peer_counts(&mut self) {
+    pub async fn refresh_peer_counts(&mut self) {
         if self.peer_last_refreshed.elapsed() > Duration::from_secs(PEER_REFRESH_INTERVAL_SECS) {
             let random_peer = PeerId::random();
             self.swarm

--- a/src/p2p/message.rs
+++ b/src/p2p/message.rs
@@ -15,6 +15,12 @@ use serde::{Deserialize, Serialize};
 
 /// A parsed message from gossipsub. When first received, the message data is simply a vector of bytes.
 /// We treat that bytearray as a stringified JSON object, and parse it into this struct.
+///
+/// TODO: these are all available at protocol level as well
+/// - payload is the data itself
+/// - topic is available as TopicHash of Gossipsub
+/// - version is given within the Identify protocol
+/// - timestamp is available at protocol level via DataTransform
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct P2PMessage {
     pub(crate) payload: String,


### PR DESCRIPTION
- Uses a bounded `send_queue` within the fork of libp2p, send queue size is limited to 400
- Small refactors and docs