### PR TITLE
better peer addr, check listen addr in use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-compute"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -998,6 +998,7 @@ dependencies = [
  "ollama-workflows",
  "openssl",
  "parking_lot",
+ "port_check",
  "rand 0.8.5",
  "reqwest 0.12.8",
  "serde",
@@ -3759,6 +3760,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "port_check"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2110609fb863cdb367d4e69d6c43c81ba6a8c7d18e80082fe9f3ef16b23afeed"
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkn-compute"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
@@ -70,6 +70,7 @@ libp2p = { git = "https://github.com/anilaltuner/rust-libp2p.git", rev = "7ce9f9
 libp2p-identity = { version = "0.2.9", features = ["secp256k1"] }
 tracing = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+port_check = "0.2.1"
 
 # Vendor OpenSSL so that its easier to build cross-platform packages
 [dependencies.openssl]

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ async fn main() -> Result<()> {
 
     // create configurations & check required services
     let config = DriaComputeNodeConfig::new();
+    config.check_address_in_use()?;
     let service_check_token = token.clone();
     let mut config_clone = config.clone();
     let service_check_handle = tokio::spawn(async move {

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,6 @@
 use eyre::{eyre, Result};
-use libp2p::{gossipsub, Multiaddr};
-use std::{str::FromStr, time::Duration};
+use libp2p::gossipsub;
+use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -40,7 +40,6 @@ impl DriaComputeNode {
         cancellation: CancellationToken,
     ) -> Result<Self> {
         let keypair = secret_to_keypair(&config.secret_key);
-        let listen_addr = Multiaddr::from_str(config.p2p_listen_addr.as_str())?;
 
         // get available nodes (bootstrap, relay, rpc) for p2p
         let available_nodes = AvailableNodes::default()
@@ -53,7 +52,7 @@ impl DriaComputeNode {
             )
             .sort_dedup();
 
-        let p2p = P2PClient::new(keypair, listen_addr, &available_nodes)?;
+        let p2p = P2PClient::new(keypair, config.p2p_listen_addr.clone(), &available_nodes)?;
 
         Ok(DriaComputeNode {
             p2p,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,7 +7,12 @@ pub use message::DKNMessage;
 mod available_nodes;
 pub use available_nodes::AvailableNodes;
 
-use std::time::{Duration, SystemTime};
+use libp2p::{multiaddr::Protocol, Multiaddr};
+use port_check::is_port_reachable;
+use std::{
+    net::{Ipv4Addr, SocketAddrV4},
+    time::{Duration, SystemTime},
+};
 
 /// Returns the current time in nanoseconds since the Unix epoch.
 ///
@@ -21,6 +26,34 @@ pub fn get_current_time_nanos() -> u128 {
             Duration::new(0, 0)
         })
         .as_nanos()
+}
+
+/// Checks if a given address is already in use locally.
+/// This is mostly used to see if the P2P address is already in use.
+///
+/// Simply tries to connect with TCP to the given address.
+#[inline]
+pub fn address_in_use(addr: &Multiaddr) -> bool {
+    addr.iter()
+        // find the port within our multiaddr
+        .find_map(|p| {
+            if let Protocol::Tcp(port) = p {
+                Some(port)
+            } else {
+                None
+            }
+
+            // }
+        })
+        // check if its reachable or not
+        .map(|port| is_port_reachable(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)))
+        .unwrap_or_else(|| {
+            log::error!(
+                "Could not find any TCP port in the given address: {:?}",
+                addr
+            );
+            false
+        })
 }
 
 /// Utility to parse comma-separated string values, mostly read from the environment.


### PR DESCRIPTION
- Now loops through `info.listen_addrs` and adds non-private and non-loopback addresses to Kademlia, instead of just adding `info.observed_addr`. In fact, we dont add `info.observed_addr` anymore.
- Now checks if own listen address is in use (e.g. compute node is running in the same machine already) gives an error, so we can detect it early and not have the trouble of not finding peers.
- Bumps version to 0.2.9