### PR TITLE
Behaviour Error Handling

### DIFF
--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map;
 use std::hash::{Hash, Hasher};
 use std::time::Duration;
 
-use eyre::{eyre, Result};
+use eyre::{eyre, Context, Result};
 use libp2p::identity::{Keypair, PeerId, PublicKey};
 use libp2p::kad::store::MemoryStore;
 use libp2p::StreamProtocol;
@@ -139,28 +139,22 @@ fn create_gossipsub_behavior(author: PeerId) -> Result<gossipsub::Behaviour> {
     };
 
     // TODO: add data transform here later
-    let config = match ConfigBuilder::default()
-        .heartbeat_interval(Duration::from_secs(HEARTBEAT_INTERVAL_SECS))
-        .max_transmit_size(MAX_TRANSMIT_SIZE)
-        .message_id_fn(message_id_fn)
-        .message_capacity(MESSAGE_CAPACITY)
-        .message_ttl(Duration::from_secs(MESSAGE_TTL_SECS))
-        .gossip_ttl(Duration::from_secs(GOSSIP_TTL_SECS))
-        .duplicate_cache_time(Duration::from_secs(DUPLICATE_CACHE_TIME_SECS))
-        .max_ihave_length(MAX_IHAVE_LENGTH)
-        .send_queue_size(MAX_SEND_QUEUE_SIZE)
-        .validation_mode(VALIDATION_MODE)
-        .validate_messages()
-        .build()
-    {
-        Ok(config) => config,
-        Err(e) => {
-            return Err(eyre!("Failed to create gossipsub config: {}", e));
-        }
-    };
-
-    match Behaviour::new(MessageAuthenticity::Author(author), config) {
-        Ok(behaviour) => Ok(behaviour),
-        Err(e) => Err(eyre!("Failed to create gossipsub behaviour: {}", e)),
-    }
+    Behaviour::new(
+        MessageAuthenticity::Author(author),
+        ConfigBuilder::default()
+            .heartbeat_interval(Duration::from_secs(HEARTBEAT_INTERVAL_SECS))
+            .max_transmit_size(MAX_TRANSMIT_SIZE)
+            .message_id_fn(message_id_fn)
+            .message_capacity(MESSAGE_CAPACITY)
+            .message_ttl(Duration::from_secs(MESSAGE_TTL_SECS))
+            .gossip_ttl(Duration::from_secs(GOSSIP_TTL_SECS))
+            .duplicate_cache_time(Duration::from_secs(DUPLICATE_CACHE_TIME_SECS))
+            .max_ihave_length(MAX_IHAVE_LENGTH)
+            .send_queue_size(MAX_SEND_QUEUE_SIZE)
+            .validation_mode(VALIDATION_MODE)
+            .validate_messages()
+            .build()
+            .wrap_err(eyre!("Failed to create config"))?,
+    )
+    .map_err(|e| eyre!(e))
 }

--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -30,7 +30,8 @@ impl DriaBehaviour {
 
         Ok(Self {
             relay: relay_behaviour,
-            gossipsub: create_gossipsub_behaviour(peer_id)?,
+            gossipsub: create_gossipsub_behaviour(peer_id)
+                .wrap_err("could not create Gossipsub behaviour")?,
             kademlia: create_kademlia_behaviour(peer_id, kademlia_protocol),
             autonat: create_autonat_behaviour(peer_id),
             dcutr: create_dcutr_behaviour(peer_id),
@@ -155,7 +156,7 @@ fn create_gossipsub_behaviour(author: PeerId) -> Result<gossipsub::Behaviour> {
             .validation_mode(VALIDATION_MODE)
             .validate_messages()
             .build()
-            .wrap_err(eyre!("Failed to create config"))?,
+            .wrap_err(eyre!("could not create Gossipsub config"))?,
     )
     .map_err(|e| eyre!(e))
 }

--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -21,26 +21,27 @@ pub struct DriaBehaviour {
 impl DriaBehaviour {
     pub fn new(
         key: &Keypair,
-        relay_behavior: relay::client::Behaviour,
+        relay_behaviour: relay::client::Behaviour,
         identity_protocol: String,
         kademlia_protocol: StreamProtocol,
     ) -> Result<Self> {
         let public_key = key.public();
         let peer_id = public_key.to_peer_id();
+
         Ok(Self {
-            relay: relay_behavior,
-            gossipsub: create_gossipsub_behavior(peer_id)?,
-            kademlia: create_kademlia_behavior(peer_id, kademlia_protocol),
-            autonat: create_autonat_behavior(peer_id),
-            dcutr: create_dcutr_behavior(peer_id),
-            identify: create_identify_behavior(public_key, identity_protocol),
+            relay: relay_behaviour,
+            gossipsub: create_gossipsub_behaviour(peer_id)?,
+            kademlia: create_kademlia_behaviour(peer_id, kademlia_protocol),
+            autonat: create_autonat_behaviour(peer_id),
+            dcutr: create_dcutr_behaviour(peer_id),
+            identify: create_identify_behaviour(public_key, identity_protocol),
         })
     }
 }
 
 /// Configures the Kademlia DHT behavior for the node.
 #[inline]
-fn create_kademlia_behavior(
+fn create_kademlia_behaviour(
     local_peer_id: PeerId,
     protocol_name: StreamProtocol,
 ) -> kad::Behaviour<MemoryStore> {
@@ -58,7 +59,7 @@ fn create_kademlia_behavior(
 
 /// Configures the Identify behavior to allow nodes to exchange information like supported protocols.
 #[inline]
-fn create_identify_behavior(
+fn create_identify_behaviour(
     local_public_key: PublicKey,
     protocol_version: String,
 ) -> identify::Behaviour {
@@ -73,7 +74,7 @@ fn create_identify_behavior(
 /// It uses a Relay for the hole-punching process, and if it succeeds the peers are
 /// connected directly without the need for the relay; otherwise, they keep using the relay.
 #[inline]
-fn create_dcutr_behavior(local_peer_id: PeerId) -> dcutr::Behaviour {
+fn create_dcutr_behaviour(local_peer_id: PeerId) -> dcutr::Behaviour {
     use dcutr::Behaviour;
 
     Behaviour::new(local_peer_id)
@@ -81,7 +82,7 @@ fn create_dcutr_behavior(local_peer_id: PeerId) -> dcutr::Behaviour {
 
 /// Configures the Autonat behavior to assist in network address translation detection.
 #[inline]
-fn create_autonat_behavior(local_peer_id: PeerId) -> autonat::Behaviour {
+fn create_autonat_behaviour(local_peer_id: PeerId) -> autonat::Behaviour {
     use autonat::{Behaviour, Config};
 
     Behaviour::new(
@@ -95,7 +96,7 @@ fn create_autonat_behavior(local_peer_id: PeerId) -> autonat::Behaviour {
 
 /// Configures the Gossipsub behavior for pub/sub messaging across peers.
 #[inline]
-fn create_gossipsub_behavior(author: PeerId) -> Result<gossipsub::Behaviour> {
+fn create_gossipsub_behaviour(author: PeerId) -> Result<gossipsub::Behaviour> {
     use gossipsub::{
         Behaviour, ConfigBuilder, Message, MessageAuthenticity, MessageId, ValidationMode,
     };

--- a/p2p/src/client.rs
+++ b/p2p/src/client.rs
@@ -141,7 +141,7 @@ impl DriaP2PClient {
         })
     }
 
-    /// Subscribe to a topic.        
+    /// Subscribe to a topic.
     pub fn subscribe(&mut self, topic_name: &str) -> Result<bool, SubscriptionError> {
         log::debug!("Subscribing to {}", topic_name);
 

--- a/p2p/src/client.rs
+++ b/p2p/src/client.rs
@@ -35,7 +35,6 @@ pub struct DriaP2PClient {
 }
 
 /// Number of seconds before an idle connection is closed.
-/// TODO: default is 0, is 60 a good value?
 const IDLE_CONNECTION_TIMEOUT_SECS: u64 = 60;
 
 /// Number of seconds between refreshing the Kademlia DHT.
@@ -72,17 +71,14 @@ impl DriaP2PClient {
             )?
             .with_quic()
             .with_relay_client(noise::Config::new, yamux::Config::default)?
-            .with_behaviour(|key, relay_behavior| {
+            .with_behaviour(|key, relay_behaviour| {
                 DriaBehaviour::new(
                     key,
-                    relay_behavior,
+                    relay_behaviour,
                     identity_protocol.clone(),
                     kademlia_protocol.clone(),
                 )
-                .unwrap_or_else(|e| {
-                    log::error!("Error creating Dria Behaviour: {:?}", e);
-                    panic!("Failed to create Dria Behaviour: {:?}", e);
-                })
+                .map_err(Into::into)
             })?
             .with_swarm_config(|c| {
                 c.with_idle_connection_timeout(Duration::from_secs(IDLE_CONNECTION_TIMEOUT_SECS))

--- a/p2p/src/client.rs
+++ b/p2p/src/client.rs
@@ -1,5 +1,5 @@
 use super::*;
-use eyre::{eyre, Result};
+use eyre::Result;
 use libp2p::futures::StreamExt;
 use libp2p::gossipsub::{
     Message, MessageAcceptance, MessageId, PublishError, SubscriptionError, TopicHash,
@@ -78,7 +78,8 @@ impl DriaP2PClient {
                     relay_behavior,
                     identity_protocol.clone(),
                     kademlia_protocol.clone(),
-                ).unwrap()
+                )
+                .unwrap()
             })?
             .with_swarm_config(|c| {
                 c.with_idle_connection_timeout(Duration::from_secs(IDLE_CONNECTION_TIMEOUT_SECS))
@@ -135,7 +136,8 @@ impl DriaP2PClient {
             identity_protocol,
             kademlia_protocol,
         })
-    }    /// Subscribe to a topic.        
+    }
+    /// Subscribe to a topic.        
     pub fn subscribe(&mut self, topic_name: &str) -> Result<bool, SubscriptionError> {
         log::debug!("Subscribing to {}", topic_name);
 

--- a/p2p/src/client.rs
+++ b/p2p/src/client.rs
@@ -1,5 +1,5 @@
 use super::*;
-use eyre::Result;
+use eyre::{eyre, Result};
 use libp2p::futures::StreamExt;
 use libp2p::gossipsub::{
     Message, MessageAcceptance, MessageId, PublishError, SubscriptionError, TopicHash,
@@ -72,13 +72,13 @@ impl DriaP2PClient {
             )?
             .with_quic()
             .with_relay_client(noise::Config::new, yamux::Config::default)?
-            .with_behaviour(|key, relay_behavior| {
-                Ok(DriaBehaviour::new(
+            .with_behaviour(|key, relay_behavior: libp2p::relay::client::Behaviour| {
+                DriaBehaviour::new(
                     key,
                     relay_behavior,
                     identity_protocol.clone(),
                     kademlia_protocol.clone(),
-                ))
+                ).unwrap()
             })?
             .with_swarm_config(|c| {
                 c.with_idle_connection_timeout(Duration::from_secs(IDLE_CONNECTION_TIMEOUT_SECS))
@@ -135,9 +135,7 @@ impl DriaP2PClient {
             identity_protocol,
             kademlia_protocol,
         })
-    }
-
-    /// Subscribe to a topic.
+    }    /// Subscribe to a topic.        
     pub fn subscribe(&mut self, topic_name: &str) -> Result<bool, SubscriptionError> {
         log::debug!("Subscribing to {}", topic_name);
 


### PR DESCRIPTION
- [x] Used `eyre::Result` instead of `expect()`
- [x] Resolves #128  


## Examples of handling gossipsub behaviour error from [rust-libp2p](https://github.com/libp2p/rust-libp2p/tree/master)

-  [ex 1](https://github.com/libp2p/rust-libp2p/blob/master/examples/chat/src/main.rs)

```
let mut swarm = libp2p::SwarmBuilder::with_new_identity()
        .with_tokio()
        .with_tcp(
            tcp::Config::default(),
            noise::Config::new,
            yamux::Config::default,
        )?
        .with_quic()
        .with_behaviour(|key| {
            // To content-address message, we can take the hash of message and use it as an ID.
            let message_id_fn = |message: &gossipsub::Message| {
                let mut s = DefaultHasher::new();
                message.data.hash(&mut s);
                gossipsub::MessageId::from(s.finish().to_string())
            };

            // Set a custom gossipsub configuration
            let gossipsub_config = gossipsub::ConfigBuilder::default()
                .heartbeat_interval(Duration::from_secs(10)) // This is set to aid debugging by not cluttering the log space
                .validation_mode(gossipsub::ValidationMode::Strict) // This sets the kind of message validation. The default is Strict (enforce message signing)
                .message_id_fn(message_id_fn) // content-address messages. No two messages of the same content will be propagated.
                .build()
                .map_err(|msg| io::Error::new(io::ErrorKind::Other, msg))?; // Temporary hack because `build` does not return a proper `std::error::Error`.

            // build a gossipsub network behaviour
            let gossipsub = gossipsub::Behaviour::new(
                gossipsub::MessageAuthenticity::Signed(key.clone()),
                gossipsub_config,
            )?;
```


- [ex 2](https://github.com/libp2p/rust-libp2p/blob/master/protocols/gossipsub/tests/smoke.rs)

```
async fn build_node() -> Swarm<gossipsub::Behaviour> {
    // NOTE: The graph of created nodes can be disconnected from the mesh point of view as nodes
    // can reach their d_lo value and not add other nodes to their mesh. To speed up this test, we
    // reduce the default values of the heartbeat, so that all nodes will receive gossip in a
    // timely fashion.

    let mut swarm = Swarm::new_ephemeral(|identity| {
        let peer_id = identity.public().to_peer_id();

        let config = gossipsub::ConfigBuilder::default()
            .heartbeat_initial_delay(Duration::from_millis(100))
            .heartbeat_interval(Duration::from_millis(200))
            .history_length(10)
            .history_gossip(10)
            .validation_mode(ValidationMode::Permissive)
            .build()
            .unwrap();
        gossipsub::Behaviour::new(MessageAuthenticity::Author(peer_id), config).unwrap()
    });
    swarm.listen().with_memory_addr_external().await;

    swarm
}
```

