### PR TITLE
feat: dummy generation requests on API checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-compute"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-p2p"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "env_logger 0.11.5",
  "eyre",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-workflows"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "dotenvy",
  "env_logger 0.11.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -112,43 +112,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "arrayref"
@@ -186,7 +186,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
  "synstructure",
 ]
 
@@ -198,7 +198,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -253,7 +253,7 @@ checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
 ]
 
 [[package]]
@@ -265,18 +265,18 @@ dependencies = [
  "async-convert",
  "backoff",
  "base64 0.22.1",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "derive_builder",
  "eventsource-stream",
  "futures",
  "rand 0.8.5",
- "reqwest 0.12.8",
+ "reqwest 0.12.9",
  "reqwest-eventsource",
  "secrecy",
  "serde",
  "serde_json",
  "thiserror",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tokio-stream",
  "tokio-util 0.7.12",
  "tracing",
@@ -290,7 +290,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -301,7 +301,7 @@ checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
 ]
 
 [[package]]
@@ -312,7 +312,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -323,7 +323,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -332,11 +332,11 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
 ]
 
 [[package]]
@@ -376,7 +376,7 @@ dependencies = [
  "derive_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -394,9 +394,9 @@ dependencies = [
  "futures-core",
  "getrandom 0.2.15",
  "instant",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
  "rand 0.8.5",
- "tokio 1.40.0",
+ "tokio 1.41.0",
 ]
 
 [[package]]
@@ -538,9 +538,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 dependencies = [
  "serde",
 ]
@@ -553,9 +553,9 @@ checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "cc"
-version = "1.1.30"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "shlex",
 ]
@@ -571,6 +571,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -623,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored"
@@ -762,7 +768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -830,7 +836,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -854,7 +860,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -865,7 +871,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -945,7 +951,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -955,7 +961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -968,7 +974,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -979,7 +985,7 @@ checksum = "65f152f4b8559c4da5d574bafc7af85454d706b4c5fe8b530d508cacbb6807ea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1010,7 +1016,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1033,12 +1039,12 @@ dependencies = [
  "openssl",
  "port_check",
  "rand 0.8.5",
- "reqwest 0.12.8",
+ "reqwest 0.12.9",
  "serde",
  "serde_json",
  "sha2 0.10.8",
  "sha3",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tokio-util 0.7.12",
  "url",
  "urlencoding",
@@ -1054,7 +1060,7 @@ dependencies = [
  "libp2p",
  "libp2p-identity",
  "log",
- "tokio 1.40.0",
+ "tokio 1.41.0",
 ]
 
 [[package]]
@@ -1067,10 +1073,10 @@ dependencies = [
  "log",
  "ollama-workflows",
  "rand 0.8.5",
- "reqwest 0.12.8",
+ "reqwest 0.12.9",
  "serde",
  "serde_json",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tokio-util 0.7.12",
 ]
 
@@ -1158,9 +1164,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1174,7 +1180,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1250,7 +1256,7 @@ checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
 ]
 
 [[package]]
@@ -1260,7 +1266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
  "event-listener",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
 ]
 
 [[package]]
@@ -1271,7 +1277,7 @@ checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
 dependencies = [
  "futures-core",
  "nom",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
 ]
 
 [[package]]
@@ -1447,12 +1453,12 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+checksum = "3f1fa2f9765705486b33fd2acf1577f8ec449c2ba1f318ae5447697b7c08d210"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
 ]
 
 [[package]]
@@ -1463,7 +1469,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1519,7 +1525,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
  "pin-utils",
  "slab",
 ]
@@ -1544,12 +1550,12 @@ dependencies = [
  "futures",
  "log",
  "pretty_env_logger",
- "reqwest 0.12.8",
+ "reqwest 0.12.9",
  "reqwest-streams",
  "serde",
  "serde_json",
  "sha256",
- "tokio 1.40.0",
+ "tokio 1.41.0",
 ]
 
 [[package]]
@@ -1643,7 +1649,7 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1651,7 +1657,7 @@ dependencies = [
  "http 0.2.12",
  "indexmap 2.6.0",
  "slab",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tokio-util 0.7.12",
  "tracing",
 ]
@@ -1663,14 +1669,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "fnv",
  "futures-core",
  "futures-sink",
  "http 1.1.0",
  "indexmap 2.6.0",
  "slab",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tokio-util 0.7.12",
  "tracing",
 ]
@@ -1763,7 +1769,7 @@ dependencies = [
  "socket2 0.5.7",
  "thiserror",
  "tinyvec",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tracing",
  "url",
 ]
@@ -1785,7 +1791,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tracing",
 ]
 
@@ -1900,7 +1906,7 @@ dependencies = [
  "markup5ever 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1909,7 +1915,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "fnv",
  "itoa 1.0.11",
 ]
@@ -1920,7 +1926,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "fnv",
  "itoa 1.0.11",
 ]
@@ -1941,9 +1947,9 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "http 0.2.12",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
 ]
 
 [[package]]
@@ -1952,7 +1958,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "http 1.1.0",
 ]
 
@@ -1962,11 +1968,11 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
 ]
 
 [[package]]
@@ -2023,7 +2029,7 @@ version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2033,9 +2039,9 @@ dependencies = [
  "httparse",
  "httpdate 1.0.3",
  "itoa 1.0.11",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
  "socket2 0.5.7",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tower-service",
  "tracing",
  "want",
@@ -2047,7 +2053,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-channel",
  "futures-util",
  "h2 0.4.6",
@@ -2056,9 +2062,9 @@ dependencies = [
  "httparse",
  "httpdate 1.0.3",
  "itoa 1.0.11",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
  "smallvec",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "want",
 ]
 
@@ -2075,7 +2081,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
@@ -2100,10 +2106,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "hyper 0.14.31",
  "native-tls",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tokio-native-tls",
 ]
 
@@ -2113,31 +2119,31 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "http-body-util",
  "hyper 1.5.0",
  "hyper-util",
  "native-tls",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tokio-native-tls",
  "tower-service",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
  "hyper 1.5.0",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
  "socket2 0.5.7",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tower-service",
  "tracing",
 ]
@@ -2216,7 +2222,7 @@ dependencies = [
  "log",
  "rtnetlink",
  "system-configuration 0.5.1",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "windows",
 ]
 
@@ -2228,13 +2234,13 @@ checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
 dependencies = [
  "async-trait",
  "attohttpc",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures",
  "http 0.2.12",
  "hyper 0.14.31",
  "log",
  "rand 0.8.5",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "url",
  "xmltree",
 ]
@@ -2395,7 +2401,7 @@ dependencies = [
  "mockito",
  "readability",
  "regex",
- "reqwest 0.12.8",
+ "reqwest 0.12.9",
  "reqwest-eventsource",
  "scraper 0.20.0",
  "secrecy",
@@ -2405,7 +2411,7 @@ dependencies = [
  "text-splitter 0.16.1",
  "thiserror",
  "tiktoken-rs",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tokio-stream",
  "url",
  "urlencoding",
@@ -2428,7 +2434,7 @@ name = "libp2p"
 version = "0.54.1"
 source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=7ce9f9e#7ce9f9e65ddbe1fdac3913f0f3c1d94edc1de25e"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "either",
  "futures",
  "futures-timer",
@@ -2477,7 +2483,7 @@ source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=7ce9f9e#7ce9f9e
 dependencies = [
  "async-trait",
  "asynchronous-codec",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "either",
  "futures",
  "futures-bounded",
@@ -2529,7 +2535,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tracing",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
  "void",
  "web-time",
 ]
@@ -2579,7 +2585,7 @@ dependencies = [
  "asynchronous-codec",
  "base64 0.22.1",
  "byteorder",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "either",
  "fnv",
  "futures",
@@ -2651,7 +2657,7 @@ source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=7ce9f9e#7ce9f9e
 dependencies = [
  "arrayvec",
  "asynchronous-codec",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "either",
  "fnv",
  "futures",
@@ -2687,7 +2693,7 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "socket2 0.5.7",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tracing",
  "void",
 ]
@@ -2718,7 +2724,7 @@ version = "0.45.0"
 source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=7ce9f9e#7ce9f9e65ddbe1fdac3913f0f3c1d94edc1de25e"
 dependencies = [
  "asynchronous-codec",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "curve25519-dalek",
  "futures",
  "libp2p-core",
@@ -2759,7 +2765,7 @@ name = "libp2p-quic"
 version = "0.11.1"
 source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=7ce9f9e#7ce9f9e65ddbe1fdac3913f0f3c1d94edc1de25e"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures",
  "futures-timer",
  "if-watch",
@@ -2773,7 +2779,7 @@ dependencies = [
  "rustls",
  "socket2 0.5.7",
  "thiserror",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tracing",
 ]
 
@@ -2783,7 +2789,7 @@ version = "0.18.0"
 source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=7ce9f9e#7ce9f9e65ddbe1fdac3913f0f3c1d94edc1de25e"
 dependencies = [
  "asynchronous-codec",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "either",
  "futures",
  "futures-bounded",
@@ -2837,7 +2843,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "smallvec",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tracing",
  "void",
  "web-time",
@@ -2851,7 +2857,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2866,7 +2872,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "socket2 0.5.7",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tracing",
 ]
 
@@ -2898,7 +2904,7 @@ dependencies = [
  "igd-next",
  "libp2p-core",
  "libp2p-swarm",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tracing",
  "void",
 ]
@@ -3188,7 +3194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09b34bd91b9e5c5b06338d392463e1318d683cf82ec3d3af4014609be6e2108d"
 dependencies = [
  "assert-json-diff",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "colored",
  "futures-util",
  "http 1.1.0",
@@ -3202,7 +3208,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "similar",
- "tokio 1.40.0",
+ "tokio 1.41.0",
 ]
 
 [[package]]
@@ -3220,7 +3226,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
  "url",
 ]
 
@@ -3237,12 +3243,12 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
+checksum = "cc41f430805af9d1cf4adae4ed2149c759b877b01d909a1f40256188d09345d2"
 dependencies = [
  "core2",
- "unsigned-varint 0.7.2",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -3250,12 +3256,12 @@ name = "multistream-select"
 version = "0.13.0"
 source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=7ce9f9e#7ce9f9e65ddbe1fdac3913f0f3c1d94edc1de25e"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures",
  "pin-project",
  "smallvec",
  "tracing",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -3330,13 +3336,13 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures",
  "log",
  "netlink-packet-core",
  "netlink-sys",
  "thiserror",
- "tokio 1.40.0",
+ "tokio 1.41.0",
 ]
 
 [[package]]
@@ -3345,11 +3351,11 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures",
  "libc",
  "log",
- "tokio 1.40.0",
+ "tokio 1.41.0",
 ]
 
 [[package]]
@@ -3462,7 +3468,7 @@ dependencies = [
  "async-trait",
  "log",
  "regex",
- "reqwest 0.12.8",
+ "reqwest 0.12.9",
  "scraper 0.19.1",
  "serde",
  "serde_json",
@@ -3473,7 +3479,7 @@ dependencies = [
 [[package]]
 name = "ollama-workflows"
 version = "0.1.0"
-source = "git+https://github.com/andthattoo/ollama-workflows#f1639c9c1efe4454e98f291ce507f46ec6f1d5c8"
+source = "git+https://github.com/andthattoo/ollama-workflows#a0b5efb03d61c3a7c30382be19568980c65a8b52"
 dependencies = [
  "async-trait",
  "colored",
@@ -3488,14 +3494,14 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "regex",
- "reqwest 0.12.8",
+ "reqwest 0.12.9",
  "scraper 0.19.1",
  "search_with_google",
  "serde",
  "serde_json",
  "simsimd",
  "text-splitter 0.13.3",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tokio-util 0.7.12",
 ]
 
@@ -3517,12 +3523,12 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf3d3fe8284533a78c1ab1cf7da0a682f6738c621a3639e55a6e8041901b151a"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "derive_builder",
- "reqwest 0.12.8",
+ "reqwest 0.12.9",
  "serde",
  "serde_json",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tokio-util 0.7.12",
 ]
 
@@ -3549,7 +3555,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3560,9 +3566,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.2+3.3.2"
+version = "300.4.0+3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
+checksum = "a709e02f2b4aca747929cca5ed248880847c650233cf8b8cdc48f40aaf4898a6"
 dependencies = [
  "cc",
 ]
@@ -3745,7 +3751,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3777,22 +3783,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3803,9 +3809,9 @@ checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -3838,7 +3844,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "concurrent-queue",
  "hermit-abi 0.4.0",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
  "rustix",
  "tracing",
  "windows-sys 0.59.0",
@@ -3912,9 +3918,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -3939,7 +3945,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3974,10 +3980,10 @@ version = "0.3.1"
 source = "git+https://github.com/anilaltuner/rust-libp2p.git?rev=7ce9f9e#7ce9f9e65ddbe1fdac3913f0f3c1d94edc1de25e"
 dependencies = [
  "asynchronous-codec",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "quick-protobuf",
  "thiserror",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -3986,16 +3992,16 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-io",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
  "rustls",
  "socket2 0.5.7",
  "thiserror",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tracing",
 ]
 
@@ -4005,7 +4011,7 @@ version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "rand 0.8.5",
  "ring 0.17.8",
  "rustc-hash 2.0.0",
@@ -4018,10 +4024,11 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
+checksum = "e346e016eacfff12233c243718197ca12f148c84e1e84268a896699b41c71780"
 dependencies = [
+ "cfg_aliases",
  "libc",
  "once_cell",
  "socket2 0.5.7",
@@ -4156,9 +4163,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4206,7 +4213,7 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
  "serde",
  "serde_urlencoded",
  "tokio 0.2.25",
@@ -4225,7 +4232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64 0.21.7",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -4241,14 +4248,14 @@ dependencies = [
  "native-tls",
  "once_cell",
  "percent-encoding",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
  "system-configuration 0.5.1",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tokio-native-tls",
  "tower-service",
  "url",
@@ -4260,12 +4267,12 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.8"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64 0.22.1",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -4285,7 +4292,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "percent-encoding",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
  "quinn",
  "rustls",
  "rustls-native-certs",
@@ -4296,7 +4303,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "system-configuration 0.6.1",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util 0.7.12",
@@ -4321,8 +4328,8 @@ dependencies = [
  "futures-timer",
  "mime",
  "nom",
- "pin-project-lite 0.2.14",
- "reqwest 0.12.8",
+ "pin-project-lite 0.2.15",
+ "reqwest 0.12.9",
  "thiserror",
 ]
 
@@ -4333,13 +4340,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee84cc47a7a0ac7562173c8f421c058e4c72089d6e662f32e2cb4bcc8e6e9201"
 dependencies = [
  "async-trait",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "cargo-husky",
  "futures",
- "reqwest 0.12.8",
+ "reqwest 0.12.9",
  "serde",
  "serde_json",
- "tokio 1.40.0",
+ "tokio 1.41.0",
  "tokio-util 0.7.12",
 ]
 
@@ -4395,7 +4402,7 @@ dependencies = [
  "netlink-proto",
  "nix",
  "thiserror",
- "tokio 1.40.0",
+ "tokio 1.41.0",
 ]
 
 [[package]]
@@ -4436,9 +4443,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -4449,9 +4456,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.15"
+version = "0.23.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
+checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
 dependencies = [
  "once_cell",
  "ring 0.17.8",
@@ -4708,29 +4715,29 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.129"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbcf9b78a125ee667ae19388837dd12294b858d101fdd393cb9d5501ef09eb2"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa 1.0.11",
  "memchr",
@@ -4800,10 +4807,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18278f6a914fa3070aa316493f7d2ddfb9ac86ebc06fa3b83bffda487e9065b0"
 dependencies = [
  "async-trait",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "hex",
  "sha2 0.10.8",
- "tokio 1.40.0",
+ "tokio 1.41.0",
 ]
 
 [[package]]
@@ -4999,7 +5006,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5021,9 +5028,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5053,7 +5060,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5175,22 +5182,22 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5284,16 +5291,16 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "libc",
  "mio 1.0.2",
  "parking_lot",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
  "signal-hook-registry",
  "socket2 0.5.7",
  "tokio-macros",
@@ -5308,7 +5315,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5318,7 +5325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio 1.40.0",
+ "tokio 1.41.0",
 ]
 
 [[package]]
@@ -5329,7 +5336,7 @@ checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
- "tokio 1.40.0",
+ "tokio 1.41.0",
 ]
 
 [[package]]
@@ -5339,8 +5346,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.14",
- "tokio 1.40.0",
+ "pin-project-lite 0.2.15",
+ "tokio 1.41.0",
 ]
 
 [[package]]
@@ -5373,13 +5380,13 @@ version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-core",
  "futures-sink",
  "futures-util",
  "hashbrown 0.14.5",
- "pin-project-lite 0.2.14",
- "tokio 1.40.0",
+ "pin-project-lite 0.2.15",
+ "tokio 1.41.0",
 ]
 
 [[package]]
@@ -5395,7 +5402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
- "pin-project-lite 0.2.14",
+ "pin-project-lite 0.2.15",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -5408,7 +5415,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5456,12 +5463,9 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"
@@ -5505,12 +5509,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "unsigned-varint"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 
 [[package]]
 name = "unsigned-varint"
@@ -5643,7 +5641,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -5677,7 +5675,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5690,9 +5688,9 @@ checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -6151,7 +6149,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6171,5 +6169,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["compute"]
 
 [workspace.package]
 edition = "2021"
-version = "0.2.17"
+version = "0.2.18"
 license = "Apache-2.0"
 readme = "README.md"
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,10 @@ profile-cpu:
 profile-mem:
 	  DKN_EXIT_TIMEOUT=120 cargo instruments --profile=profiling -t Allocations
 
-###############################################################################
+.PHONY: ollama-wf-version
+ollama-wf-version:
+	  @cat Cargo.lock | grep "https://github.com/andthattoo/ollama-workflows"
+
 .PHONY: test #         | Run tests
 test:
 		cargo test --workspace

--- a/workflows/src/providers/gemini.rs
+++ b/workflows/src/providers/gemini.rs
@@ -6,26 +6,7 @@ use std::env;
 
 use crate::utils::safe_read_env;
 
-/// [`models.list`](https://ai.google.dev/api/models#method:-models.list) endpoint
-const GEMINI_MODELS_API: &str = "https://generativelanguage.googleapis.com/v1beta/models";
 const ENV_VAR_NAME: &str = "GEMINI_API_KEY";
-
-/// [Model](https://ai.google.dev/api/models#Model) API object, fields omitted.
-#[derive(Debug, Clone, Deserialize)]
-#[allow(non_snake_case)]
-#[allow(unused)]
-struct GeminiModel {
-    name: String,
-    version: String,
-    // other fields are ignored from API response
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[allow(non_snake_case)]
-#[allow(unused)]
-struct GeminiModelsResponse {
-    models: Vec<GeminiModel>,
-}
 
 /// OpenAI-specific configurations.
 #[derive(Debug, Clone, Default)]
@@ -57,10 +38,76 @@ impl GeminiConfig {
             return Err(eyre!("Gemini API key not found"));
         };
 
+        // check if models exist and select those that are available
+        let gemini_models_names = self.fetch_models(api_key).await?;
+        let mut available_models = Vec::new();
+        for requested_model in models {
+            // check if model exists
+            if !gemini_models_names
+                .iter()
+                .any(|model| model.starts_with(&requested_model.to_string()))
+            {
+                log::warn!(
+                    "Model {} not found in your Gemini account, ignoring it.",
+                    requested_model
+                );
+                continue;
+            }
+
+            // make a dummy request
+            if let Err(err) = self.dummy_request(&api_key, &requested_model).await {
+                log::warn!(
+                    "Model {} failed dummy request, ignoring it: {}",
+                    requested_model,
+                    err
+                );
+                continue;
+            }
+
+            available_models.push(requested_model);
+        }
+
+        // log results
+        if available_models.is_empty() {
+            log::warn!("Gemini checks are finished, no available models found.",);
+        } else {
+            log::info!(
+                "Gemini checks are finished, using models: {:#?}",
+                available_models
+            );
+        }
+
+        Ok(available_models)
+    }
+
+    /// Returns the list of models available to this account.
+    ///
+    /// A gemini model name in API response is given as `models/{baseModelId}-{version}`
+    /// the model name in Workflows can include the version as well, so best bet is to check prefix
+    /// ignoring the `models/` part.
+    async fn fetch_models(&self, api_key: &str) -> Result<Vec<String>> {
+        /// [Model](https://ai.google.dev/api/models#Model) API object, fields omitted.
+        #[derive(Debug, Clone, Deserialize)]
+        #[allow(non_snake_case)]
+        #[allow(unused)]
+        struct GeminiModel {
+            name: String,
+            version: String,
+            // other fields are ignored from API response
+        }
+
+        #[derive(Debug, Clone, Deserialize)]
+        #[allow(non_snake_case)]
+        #[allow(unused)]
+        struct GeminiModelsResponse {
+            models: Vec<GeminiModel>,
+        }
+
         // fetch models
         let client = Client::new();
         let request = client
-            .get(GEMINI_MODELS_API)
+            // [`models.list`](https://ai.google.dev/api/models#method:-models.list) endpoint
+            .get("https://generativelanguage.googleapis.com/v1beta/models")
             .query(&[("key", api_key)])
             .build()
             .wrap_err("failed to build request")?;
@@ -79,33 +126,52 @@ impl GeminiConfig {
         }
         let gemini_models = response.json::<GeminiModelsResponse>().await?;
 
-        // check if models exist and select those that are available
-        let mut available_models = Vec::new();
-        for requested_model in models {
-            if !gemini_models.models.iter().any(|gemini_model| {
-                // a gemini model name in API response is given as `models/{baseModelId}-{version}`
-                // the model name in Workflows can include the version as well, so best bet is to check prefix
-                // ignoring the `models/` part
-                gemini_model
-                    .name
-                    .trim_start_matches("models/")
-                    .starts_with(&requested_model.to_string())
-            }) {
-                log::warn!(
-                    "Model {} not found in your Gemini account, ignoring it.",
-                    requested_model
-                );
-            } else {
-                available_models.push(requested_model);
-            }
+        Ok(gemini_models
+            .models
+            .into_iter()
+            .map(|model| model.name.trim_start_matches("models/").to_string())
+            .collect())
+    }
+
+    async fn dummy_request(&self, api_key: &str, model: &Model) -> Result<()> {
+        log::debug!("Making a dummy request with: {}", model);
+        let client = Client::new();
+        let request = client
+            .post(format!(
+                "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent",
+                model.to_string()
+            ))
+            .query(&[("key", api_key)])
+            .header("Content-Type", "application/json")
+            .body(
+                serde_json::json!({
+                 "contents": [{
+                   "parts":[{"text": "What is 2+2?"}]
+                  }]
+                })
+                .to_string(),
+            )
+            .build()
+            .wrap_err("failed to build request")?;
+
+        let response = client
+            .execute(request)
+            .await
+            .wrap_err("failed to send request")?;
+
+        // ensure response is ok
+        if !response.status().is_success() {
+            return Err(eyre!(
+                "Failed to make OpenAI chat request:\n{}",
+                response
+                    .text()
+                    .await
+                    .unwrap_or("Could not get error text as well".to_string())
+            ));
         }
+        log::debug!("Dummy request successful for model {}", model);
 
-        log::info!(
-            "Gemini checks are finished, using models: {:#?}",
-            available_models
-        );
-
-        Ok(available_models)
+        Ok(())
     }
 }
 
@@ -118,6 +184,8 @@ mod tests {
     async fn test_gemini_check() {
         let _ = dotenvy::dotenv(); // read api key
         assert!(env::var(ENV_VAR_NAME).is_ok(), "should have api key");
+        env::set_var("RUST_LOG", "none,dkn_workflows=debug");
+        let _ = env_logger::try_init();
 
         let models = vec![
             Model::Gemini10Pro,

--- a/workflows/src/providers/openai.rs
+++ b/workflows/src/providers/openai.rs
@@ -6,20 +6,7 @@ use std::env;
 
 use crate::utils::safe_read_env;
 
-const OPENAI_MODELS_API: &str = "https://api.openai.com/v1/models";
 const ENV_VAR_NAME: &str = "OPENAI_API_KEY";
-
-/// [Model](https://platform.openai.com/docs/api-reference/models/object) API object, fields omitted.
-#[derive(Debug, Clone, Deserialize)]
-struct OpenAIModel {
-    /// The model identifier, which can be referenced in the API endpoints.
-    id: String,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct OpenAIModelsResponse {
-    data: Vec<OpenAIModel>,
-}
 
 /// OpenAI-specific configurations.
 #[derive(Debug, Clone, Default)]
@@ -42,7 +29,7 @@ impl OpenAIConfig {
         self
     }
 
-    /// Check if requested models exist & are available in the OpenAI account.
+    /// Returns the list of model names available to this account.
     pub async fn check(&self, models: Vec<Model>) -> Result<Vec<Model>> {
         log::info!("Checking OpenAI requirements");
 
@@ -51,10 +38,62 @@ impl OpenAIConfig {
             return Err(eyre!("OpenAI API key not found"));
         };
 
-        // fetch models
+        // check if models exist within the account and select those that are available
+        let openai_model_names = self.fetch_models(&api_key).await?;
+        let mut available_models = Vec::new();
+        for requested_model in models {
+            // check if model exists
+            if !openai_model_names.contains(&requested_model.to_string()) {
+                log::warn!(
+                    "Model {} not found in your OpenAI account, ignoring it.",
+                    requested_model
+                );
+                continue;
+            }
+
+            // make a dummy request
+            if let Err(err) = self.dummy_request(&api_key, &requested_model).await {
+                log::warn!(
+                    "Model {} failed dummy request, ignoring it: {}",
+                    requested_model,
+                    err
+                );
+                continue;
+            }
+
+            available_models.push(requested_model)
+        }
+
+        // log results
+        if available_models.is_empty() {
+            log::warn!("OpenAI checks are finished, no available models found.",);
+        } else {
+            log::info!(
+                "OpenAI checks are finished, using models: {:#?}",
+                available_models
+            );
+        }
+
+        Ok(available_models)
+    }
+
+    /// Fetches the list of models available in the OpenAI account.
+    async fn fetch_models(&self, api_key: &str) -> Result<Vec<String>> {
+        /// [Model](https://platform.openai.com/docs/api-reference/models/object) API object, fields omitted.
+        #[derive(Debug, Clone, Deserialize)]
+        struct OpenAIModel {
+            /// The model identifier, which can be referenced in the API endpoints.
+            id: String,
+        }
+
+        #[derive(Debug, Clone, Deserialize)]
+        struct OpenAIModelsResponse {
+            data: Vec<OpenAIModel>,
+        }
+
         let client = Client::new();
         let request = client
-            .get(OPENAI_MODELS_API)
+            .get("https://api.openai.com/v1/models")
             .header("Authorization", format!("Bearer {}", api_key))
             .build()
             .wrap_err("failed to build request")?;
@@ -65,36 +104,61 @@ impl OpenAIConfig {
             .wrap_err("failed to send request")?;
 
         // parse response
-        if response.status().is_client_error() {
+        if !response.status().is_success() {
             return Err(eyre!(
                 "Failed to fetch OpenAI models:\n{}",
-                response.text().await.unwrap_or_default()
+                response
+                    .text()
+                    .await
+                    .unwrap_or("Could not get error text as well".to_string())
+            ));
+        } else {
+            let openai_models = response.json::<OpenAIModelsResponse>().await?;
+            Ok(openai_models.data.into_iter().map(|m| m.id).collect())
+        }
+    }
+
+    /// Makes a dummy request to the OpenAI API to check if the model is available & has credits.
+    async fn dummy_request(&self, api_key: &str, model: &Model) -> Result<()> {
+        log::debug!("Making a dummy request with: {}", model);
+        let client = Client::new();
+        let request = client
+            .post("https://api.openai.com/v1/chat/completions")
+            .header("Authorization", format!("Bearer {}", api_key))
+            .header("Content-Type", "application/json")
+            .body(
+                serde_json::json!({
+                  "model": model.to_string(),
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "What is 2+2?"
+                    }
+                  ]
+                })
+                .to_string(),
+            )
+            .build()
+            .wrap_err("failed to build request")?;
+
+        let response = client
+            .execute(request)
+            .await
+            .wrap_err("failed to send request")?;
+
+        // ensure response is ok
+        if !response.status().is_success() {
+            return Err(eyre!(
+                "Failed to make OpenAI chat request:\n{}",
+                response
+                    .text()
+                    .await
+                    .unwrap_or("Could not get error text as well".to_string())
             ));
         }
-        let openai_models = response.json::<OpenAIModelsResponse>().await?;
+        log::debug!("Dummy request successful for model {}", model);
 
-        // check if models exist and select those that are available
-        let mut available_models = Vec::new();
-        for requested_model in models {
-            if !openai_models
-                .data
-                .iter()
-                .any(|m| m.id == requested_model.to_string())
-            {
-                log::warn!(
-                    "Model {} not found in your OpenAI account, ignoring it.",
-                    requested_model
-                );
-            } else {
-                available_models.push(requested_model);
-            }
-        }
-
-        log::info!(
-            "OpenAI checks are finished, using models: {:#?}",
-            available_models
-        );
-        Ok(available_models)
+        Ok(())
     }
 }
 
@@ -107,6 +171,8 @@ mod tests {
     async fn test_openai_check() {
         let _ = dotenvy::dotenv(); // read api key
         assert!(env::var(ENV_VAR_NAME).is_ok(), "should have api key");
+        env::set_var("RUST_LOG", "none,dkn_workflows=debug");
+        let _ = env_logger::try_init();
 
         let models = vec![Model::GPT4Turbo, Model::GPT4o, Model::GPT4oMini];
         let config = OpenAIConfig::new();


### PR DESCRIPTION
- [x] When OpenAI or Gemini models are used, we do a dummy generation request for them. This help catch more edge-cases such as regional blocks or depleted credits.
- [x] Bumps version to 0.2.18.
- [x] New models in Ollama Workflows