### PR TITLE
feat: multi-network & peer disconnections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,6 +1014,7 @@ dependencies = [
  "libp2p-identity",
  "log",
  "tokio 1.41.1",
+ "tokio-util 0.7.12",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-compute"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-p2p"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "env_logger 0.11.5",
  "eyre",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-workflows"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "dotenvy",
  "env_logger 0.11.5",
@@ -2252,7 +2252,7 @@ dependencies = [
  "rtnetlink",
  "system-configuration",
  "tokio 1.41.1",
- "windows 0.51.1",
+ "windows 0.53.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["compute"]
 
 [workspace.package]
 edition = "2021"
-version = "0.2.22"
+version = "0.2.23"
 license = "Apache-2.0"
 readme = "README.md"
 

--- a/compute/src/config.rs
+++ b/compute/src/config.rs
@@ -9,6 +9,33 @@ use libsecp256k1::{PublicKey, SecretKey};
 
 use std::{env, str::FromStr};
 
+/// Network type.
+#[derive(Default, Debug, Clone, Copy)]
+pub enum DriaNetworkType {
+    #[default]
+    Community,
+    Pro,
+}
+
+impl From<&str> for DriaNetworkType {
+    fn from(s: &str) -> Self {
+        match s {
+            "community" => DriaNetworkType::Community,
+            "pro" => DriaNetworkType::Pro,
+            _ => Default::default(),
+        }
+    }
+}
+
+impl DriaNetworkType {
+    pub fn protocol_name(&self) -> &str {
+        match self {
+            DriaNetworkType::Community => "dria",
+            DriaNetworkType::Pro => "dria-sdk",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct DriaComputeNodeConfig {
     /// Wallet secret/private key.
@@ -23,6 +50,8 @@ pub struct DriaComputeNodeConfig {
     pub p2p_listen_addr: Multiaddr,
     /// Workflow configurations, e.g. models and providers.
     pub workflows: DriaWorkflowsConfig,
+    /// Network type of the node.
+    pub network_type: DriaNetworkType,
 }
 
 /// The default P2P network listen address.
@@ -104,6 +133,11 @@ impl DriaComputeNodeConfig {
         let p2p_listen_addr = Multiaddr::from_str(&p2p_listen_addr_str)
             .expect("Could not parse the given P2P listen address.");
 
+        // parse network type
+        let network_type = env::var("DKN_NETWORK")
+            .map(|s| DriaNetworkType::from(s.as_str()))
+            .unwrap_or_default();
+
         Self {
             admin_public_key,
             secret_key,
@@ -111,6 +145,7 @@ impl DriaComputeNodeConfig {
             address,
             workflows,
             p2p_listen_addr,
+            network_type,
         }
     }
 

--- a/compute/src/handlers/pingpong.rs
+++ b/compute/src/handlers/pingpong.rs
@@ -64,7 +64,7 @@ impl ComputeHandler for PingpongHandler {
             Self::RESPONSE_TOPIC,
             &node.config.secret_key,
         );
-        node.publish(message)?;
+        node.publish(message).await?;
 
         Ok(MessageAcceptance::Accept)
     }

--- a/compute/src/handlers/workflow.rs
+++ b/compute/src/handlers/workflow.rs
@@ -161,7 +161,7 @@ impl ComputeHandler for WorkflowHandler {
         };
 
         // try publishing the result
-        if let Err(publish_err) = node.publish(message) {
+        if let Err(publish_err) = node.publish(message).await {
             let err_msg = format!("Could not publish result: {:?}", publish_err);
             log::error!("{}", err_msg);
 
@@ -174,7 +174,7 @@ impl ComputeHandler for WorkflowHandler {
                 Self::RESPONSE_TOPIC,
                 &node.config.secret_key,
             );
-            node.publish(message)?;
+            node.publish(message).await?;
         }
 
         Ok(acceptance)

--- a/compute/src/handlers/workflow.rs
+++ b/compute/src/handlers/workflow.rs
@@ -161,7 +161,6 @@ impl ComputeHandler for WorkflowHandler {
         };
 
         // try publishing the result
-
         if let Err(publish_err) = node.publish(message) {
             let err_msg = format!("Could not publish result: {:?}", publish_err);
             log::error!("{}", err_msg);

--- a/compute/src/lib.rs
+++ b/compute/src/lib.rs
@@ -11,5 +11,5 @@ pub(crate) mod utils;
 /// This value is attached within the published messages.
 pub const DRIA_COMPUTE_NODE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub use config::DriaComputeNodeConfig;
+pub use config::{DriaComputeNodeConfig, DriaNetworkType};
 pub use node::DriaComputeNode;

--- a/compute/src/main.rs
+++ b/compute/src/main.rs
@@ -158,6 +158,7 @@ async fn wait_for_termination(cancellation: CancellationToken) -> Result<()> {
     Ok(())
 }
 
+// #[deprecated]
 /// Very CRUDE fix due to launcher log level bug
 ///
 /// TODO: remove me later when the launcher is fixed

--- a/compute/src/main.rs
+++ b/compute/src/main.rs
@@ -1,5 +1,5 @@
 use dkn_compute::*;
-use eyre::{Context, Result};
+use eyre::Result;
 use std::env;
 use tokio_util::sync::CancellationToken;
 
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
 ██║  ██║██╔══██╗██║██╔══██║   https://dria.co
 ██████╔╝██║  ██║██║██║  ██║
 ╚═════╝ ╚═╝  ╚═╝╚═╝╚═╝  ╚═╝
-"#,
+"#
     );
 
     let token = CancellationToken::new();
@@ -52,10 +52,6 @@ async fn main() -> Result<()> {
     let service_check_token = token.clone();
     let config = tokio::spawn(async move {
         tokio::select! {
-            _ = service_check_token.cancelled() => {
-                log::info!("Service check cancelled.");
-                config
-            }
             result = config.workflows.check_services() => {
                 if let Err(err) = result {
                     log::error!("Error checking services: {:?}", err);
@@ -64,37 +60,43 @@ async fn main() -> Result<()> {
                 log::warn!("Using models: {:#?}", config.workflows.models);
                 config
             }
+            _ = service_check_token.cancelled() => {
+                log::info!("Service check cancelled.");
+                config
+            }
         }
     })
-    .await
-    .wrap_err("error during service checks")?;
+    .await?;
 
-    if !token.is_cancelled() {
-        // launch the node in a separate thread
-        let node_token = token.clone();
-        let node_handle = tokio::spawn(async move {
-            match DriaComputeNode::new(config, node_token).await {
-                Ok(mut node) => {
-                    if let Err(err) = node.launch().await {
-                        log::error!("Node launch error: {}", err);
-                        panic!("Node failed.")
-                    };
-                }
-                Err(err) => {
-                    log::error!("Node setup error: {}", err);
-                    panic!("Could not setup node.")
-                }
-            }
-        });
-
-        // wait for tasks to complete
-        if let Err(err) = node_handle.await {
-            log::error!("Node handle error: {}", err);
-            panic!("Could not exit Node thread handle.");
-        };
-    } else {
-        log::warn!("Not launching node due to early exit.");
+    // check early exit due to failed service check
+    if token.is_cancelled() {
+        log::warn!("Not launching node due to early exit, bye!");
+        return Ok(());
     }
+
+    let node_token = token.clone();
+    let (mut node, p2p) = DriaComputeNode::new(config, node_token).await?;
+
+    // launch the p2p in a separate thread
+    log::info!("Spawning peer-to-peer client thread.");
+    let p2p_handle = tokio::spawn(async move { p2p.run().await });
+
+    // launch the node in a separate thread
+    log::info!("Spawning compute node thread.");
+    let node_handle = tokio::spawn(async move {
+        if let Err(err) = node.launch().await {
+            log::error!("Node launch error: {}", err);
+            panic!("Node failed.")
+        };
+    });
+
+    // wait for tasks to complete
+    if let Err(err) = node_handle.await {
+        log::error!("Node handle error: {}", err);
+    };
+    if let Err(err) = p2p_handle.await {
+        log::error!("P2P handle error: {}", err);
+    };
 
     log::info!("Bye!");
     Ok(())

--- a/compute/src/node.rs
+++ b/compute/src/node.rs
@@ -156,8 +156,6 @@ impl DriaComputeNode {
                         log::debug!("{:?}", self.p2p.network_info().connection_counters());
                     }
 
-
-
                     let (peer_id, message_id, message) = event;
                     let topic = message.topic.clone();
                     let topic_str = topic.as_str();

--- a/compute/src/node.rs
+++ b/compute/src/node.rs
@@ -53,8 +53,8 @@ impl DriaComputeNode {
         let mut p2p = DriaP2PClient::new(
             keypair,
             config.p2p_listen_addr.clone(),
-            &available_nodes.bootstrap_nodes,
-            &available_nodes.relay_nodes,
+            available_nodes.bootstrap_nodes.clone().into_iter(),
+            available_nodes.relay_nodes.clone().into_iter(),
             protocol,
         )?;
 
@@ -144,13 +144,13 @@ impl DriaComputeNode {
                         };
 
                         // dial all rpc nodes for better connectivity
-                        for rpc_addr in self.available_nodes.rpc_addrs.iter() {
-                            log::debug!("Dialling RPC node: {}", rpc_addr);
-                            // TODO: does this cause resource issues?
-                            if let Err(e) = self.p2p.dial(rpc_addr.clone()) {
-                                log::warn!("Error dialling RPC node: {:?}", e);
-                            };
-                        }
+                        // for rpc_addr in self.available_nodes.rpc_addrs.iter() {
+                        //     log::debug!("Dialling RPC node: {}", rpc_addr);
+                        //     // TODO: does this cause resource issues?
+                        //     if let Err(e) = self.p2p.dial(rpc_addr.clone()) {
+                        //         log::warn!("Error dialling RPC node: {:?}", e);
+                        //     };
+                        // }
 
                         // also print network info
                         log::debug!("{:?}", self.p2p.network_info().connection_counters());

--- a/compute/src/node.rs
+++ b/compute/src/node.rs
@@ -1,5 +1,15 @@
-use dkn_p2p::{libp2p::gossipsub, DriaP2PClient, DriaP2PProtocol};
+use dkn_p2p::{
+    libp2p::{
+        gossipsub::{self, Message, MessageId},
+        PeerId,
+    },
+    DriaP2PClient, DriaP2PCommander, DriaP2PProtocol,
+};
 use eyre::{eyre, Result};
+use tokio::{
+    sync::mpsc,
+    time::{Duration, Instant},
+};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -7,6 +17,9 @@ use crate::{
     handlers::*,
     utils::{crypto::secret_to_keypair, AvailableNodes, DKNMessage},
 };
+
+/// Number of seconds between refreshing the Kademlia DHT.
+const PEER_REFRESH_INTERVAL_SECS: u64 = 30;
 
 /// **Dria Compute Node**
 ///
@@ -23,16 +36,18 @@ use crate::{
 /// ```
 pub struct DriaComputeNode {
     pub config: DriaComputeNodeConfig,
-    pub p2p: DriaP2PClient,
+    pub p2p: DriaP2PCommander,
     pub available_nodes: AvailableNodes,
     pub cancellation: CancellationToken,
+    peer_last_refreshed: Instant,
+    msg_rx: mpsc::Receiver<(PeerId, MessageId, Message)>,
 }
 
 impl DriaComputeNode {
     pub async fn new(
         config: DriaComputeNodeConfig,
         cancellation: CancellationToken,
-    ) -> Result<Self> {
+    ) -> Result<(Self, DriaP2PClient)> {
         // create the keypair from secret key
         let keypair = secret_to_keypair(&config.secret_key);
 
@@ -50,35 +65,31 @@ impl DriaComputeNode {
         log::info!("Using identity: {}", protocol);
 
         // create p2p client
-        let mut p2p = DriaP2PClient::new(
+        let (p2p_client, p2p_commander, msg_rx) = DriaP2PClient::new(
             keypair,
             config.p2p_listen_addr.clone(),
             available_nodes.bootstrap_nodes.clone().into_iter(),
             available_nodes.relay_nodes.clone().into_iter(),
+            available_nodes.rpc_addrs.clone().into_iter(),
             protocol,
         )?;
 
-        // dial rpc nodes
-        if available_nodes.rpc_addrs.is_empty() {
-            log::warn!("No RPC nodes found to be dialled!");
-        } else {
-            for rpc_addr in &available_nodes.rpc_addrs {
-                log::info!("Dialing RPC node: {}", rpc_addr);
-                p2p.dial(rpc_addr.clone())?;
-            }
-        }
-
-        Ok(DriaComputeNode {
-            p2p,
-            config,
-            cancellation,
-            available_nodes,
-        })
+        Ok((
+            DriaComputeNode {
+                config,
+                p2p: p2p_commander,
+                cancellation,
+                available_nodes,
+                msg_rx,
+                peer_last_refreshed: Instant::now(),
+            },
+            p2p_client,
+        ))
     }
 
     /// Subscribe to a certain task with its topic.
-    pub fn subscribe(&mut self, topic: &str) -> Result<()> {
-        let ok = self.p2p.subscribe(topic)?;
+    pub async fn subscribe(&mut self, topic: &str) -> Result<()> {
+        let ok = self.p2p.subscribe(topic).await?;
         if ok {
             log::info!("Subscribed to {}", topic);
         } else {
@@ -87,9 +98,25 @@ impl DriaComputeNode {
         Ok(())
     }
 
+    /// Validates a message, but only logs the error.
+    pub async fn validate_safe(
+        &mut self,
+        msg_id: &gossipsub::MessageId,
+        propagation_source: &PeerId,
+        acceptance: gossipsub::MessageAcceptance,
+    ) {
+        if let Err(e) = self
+            .p2p
+            .validate_message(msg_id, propagation_source, acceptance)
+            .await
+        {
+            log::error!("Error validating message: {:?}", e);
+        }
+    }
+
     /// Unsubscribe from a certain task with its topic.
-    pub fn unsubscribe(&mut self, topic: &str) -> Result<()> {
-        let ok = self.p2p.unsubscribe(topic)?;
+    pub async fn unsubscribe(&mut self, topic: &str) -> Result<()> {
+        let ok = self.p2p.unsubscribe(topic).await?;
         if ok {
             log::info!("Unsubscribed from {}", topic);
         } else {
@@ -102,39 +129,41 @@ impl DriaComputeNode {
     ///
     /// Internally, identity is attached to the the message which is then JSON serialized to bytes
     /// and then published to the network as is.
-    pub fn publish(&mut self, mut message: DKNMessage) -> Result<()> {
-        message = message.with_identity(self.p2p.protocol().identity());
+    pub async fn publish(&mut self, mut message: DKNMessage) -> Result<()> {
+        // attach protocol name to the message
+        message = message.with_identity(self.p2p.protocol().name.clone());
+
         let message_bytes = serde_json::to_vec(&message)?;
-        let message_id = self.p2p.publish(&message.topic, message_bytes)?;
+        let message_id = self.p2p.publish(&message.topic, message_bytes).await?;
         log::info!("Published message ({}) to {}", message_id, message.topic);
         Ok(())
     }
 
     /// Returns the list of connected peers.
-    #[inline(always)]
-    pub fn peers(
-        &self,
-    ) -> Vec<(
-        &dkn_p2p::libp2p_identity::PeerId,
-        Vec<&gossipsub::TopicHash>,
-    )> {
-        self.p2p.peers()
-    }
+    // #[inline(always)]
+    // pub fn peers(
+    //     &self,
+    // ) -> Vec<(
+    //     &dkn_p2p::libp2p_identity::PeerId,
+    //     Vec<&gossipsub::TopicHash>,
+    // )> {
+    //     self.p2p.peers()
+    // }
 
     /// Launches the main loop of the compute node.
     /// This method is not expected to return until cancellation occurs.
     pub async fn launch(&mut self) -> Result<()> {
         // subscribe to topics
-        self.subscribe(PingpongHandler::LISTEN_TOPIC)?;
-        self.subscribe(PingpongHandler::RESPONSE_TOPIC)?;
-        self.subscribe(WorkflowHandler::LISTEN_TOPIC)?;
-        self.subscribe(WorkflowHandler::RESPONSE_TOPIC)?;
+        self.subscribe(PingpongHandler::LISTEN_TOPIC).await?;
+        self.subscribe(PingpongHandler::RESPONSE_TOPIC).await?;
+        self.subscribe(WorkflowHandler::LISTEN_TOPIC).await?;
+        self.subscribe(WorkflowHandler::RESPONSE_TOPIC).await?;
 
         // main loop, listens for message events in particular
         // the underlying p2p client is expected to handle the rest within its own loop
         loop {
             tokio::select! {
-                event = self.p2p.process_events() => {
+                event = self.msg_rx.recv() => {
                     // refresh admin rpc peer ids
                     if self.available_nodes.can_refresh() {
                         log::info!("Refreshing available nodes.");
@@ -144,19 +173,32 @@ impl DriaComputeNode {
                         };
 
                         // dial all rpc nodes for better connectivity
-                        // for rpc_addr in self.available_nodes.rpc_addrs.iter() {
-                        //     log::debug!("Dialling RPC node: {}", rpc_addr);
-                        //     // TODO: does this cause resource issues?
-                        //     if let Err(e) = self.p2p.dial(rpc_addr.clone()) {
-                        //         log::warn!("Error dialling RPC node: {:?}", e);
-                        //     };
-                        // }
+                        for rpc_addr in self.available_nodes.rpc_addrs.iter() {
+                            log::debug!("Dialling RPC node: {}", rpc_addr);
+                            if let Err(e) = self.p2p.dial(rpc_addr.clone()).await {
+                                log::warn!("Error dialling RPC node: {:?}", e);
+                            };
+                        }
 
-                        // also print network info
-                        log::debug!("{:?}", self.p2p.network_info().connection_counters());
+                        // print network info
+                        log::debug!("{:?}", self.p2p.network_info().await);
                     }
 
-                    let (peer_id, message_id, message) = event;
+                    // check peer count
+                    if self.peer_last_refreshed.elapsed() > Duration::from_secs(PEER_REFRESH_INTERVAL_SECS) {
+                        let (mesh_cnt, all_cnt) = self.p2p.peer_counts().await.unwrap_or((0, 0));
+                        log::info!("Peer Count (mesh/all): {} / {}", mesh_cnt, all_cnt);
+
+                        self.peer_last_refreshed = Instant::now();
+
+                        // TODO: add peer list as well
+                    }
+
+                    // check if there was any event at all
+                    let Some((peer_id, message_id, message)) = event else {
+                        continue;
+                    };
+
                     let topic = message.topic.clone();
                     let topic_str = topic.as_str();
 
@@ -167,7 +209,7 @@ impl DriaComputeNode {
                             Some(peer) => peer,
                             None => {
                                 log::warn!("Received {} message from {} without source.", topic_str, peer_id);
-                                self.p2p.validate_message(&message_id, &peer_id, gossipsub::MessageAcceptance::Ignore)?;
+                                self.validate_safe(&message_id, &peer_id, gossipsub::MessageAcceptance::Ignore).await;
                                 continue;
                             }
                         };
@@ -184,7 +226,7 @@ impl DriaComputeNode {
                         if !self.available_nodes.rpc_nodes.contains(&source_peer_id) {
                             log::warn!("Received message from unauthorized source: {}", source_peer_id);
                             log::debug!("Allowed sources: {:#?}", self.available_nodes.rpc_nodes);
-                            self.p2p.validate_message(&message_id, &peer_id, gossipsub::MessageAcceptance::Ignore)?;
+                            self.validate_safe(&message_id, &peer_id, gossipsub::MessageAcceptance::Ignore).await;
                             continue;
                         }
 
@@ -195,7 +237,7 @@ impl DriaComputeNode {
                             Err(e) => {
                                 log::error!("Error parsing message: {:?}", e);
                                 log::debug!("Message: {}", String::from_utf8_lossy(&message.data));
-                                self.p2p.validate_message(&message_id, &peer_id, gossipsub::MessageAcceptance::Ignore)?;
+                                self.validate_safe(&message_id, &peer_id, gossipsub::MessageAcceptance::Ignore).await;
                                 continue;
                             }
                         };
@@ -208,30 +250,29 @@ impl DriaComputeNode {
                             PingpongHandler::LISTEN_TOPIC => {
                                 PingpongHandler::handle_compute(self, message).await
                             }
-                            // TODO: can we do this in a nicer way?
-                            // TODO: yes, cast to enum above and let type-casting do the work
+                            // TODO: can we do this in a nicer way? yes, cast to enum above and let type-casting do the work
                             _ => unreachable!() // unreachable because of the if condition
                         };
 
                         // validate the message based on the result
                         match handler_result {
                             Ok(acceptance) => {
-                                self.p2p.validate_message(&message_id, &peer_id, acceptance)?;
+                                self.validate_safe(&message_id, &peer_id, acceptance).await;
                             },
                             Err(err) => {
                                 log::error!("Error handling {} message: {:?}", topic_str, err);
-                                self.p2p.validate_message(&message_id, &peer_id, gossipsub::MessageAcceptance::Ignore)?;
+                                self.validate_safe(&message_id, &peer_id, gossipsub::MessageAcceptance::Ignore).await;
                             }
                         }
                     } else if std::matches!(topic_str, PingpongHandler::RESPONSE_TOPIC | WorkflowHandler::RESPONSE_TOPIC) {
                         // since we are responding to these topics, we might receive messages from other compute nodes
                         // we can gracefully ignore them and propagate it to to others
                         log::trace!("Ignoring message for topic: {}", topic_str);
-                        self.p2p.validate_message(&message_id, &peer_id, gossipsub::MessageAcceptance::Accept)?;
+                        self.validate_safe(&message_id, &peer_id, gossipsub::MessageAcceptance::Accept).await;
                     } else {
                         // reject this message as its from a foreign topic
                         log::warn!("Received message from unexpected topic: {}", topic_str);
-                        self.p2p.validate_message(&message_id, &peer_id, gossipsub::MessageAcceptance::Reject)?;
+                        self.validate_safe(&message_id, &peer_id, gossipsub::MessageAcceptance::Reject).await;
                     }
                 },
                 _ = self.cancellation.cancelled() => break,
@@ -239,10 +280,17 @@ impl DriaComputeNode {
         }
 
         // unsubscribe from topics
-        self.unsubscribe(PingpongHandler::LISTEN_TOPIC)?;
-        self.unsubscribe(PingpongHandler::RESPONSE_TOPIC)?;
-        self.unsubscribe(WorkflowHandler::LISTEN_TOPIC)?;
-        self.unsubscribe(WorkflowHandler::RESPONSE_TOPIC)?;
+        self.unsubscribe(PingpongHandler::LISTEN_TOPIC).await?;
+        self.unsubscribe(PingpongHandler::RESPONSE_TOPIC).await?;
+        self.unsubscribe(WorkflowHandler::LISTEN_TOPIC).await?;
+        self.unsubscribe(WorkflowHandler::RESPONSE_TOPIC).await?;
+
+        // send shutdown signal
+        self.p2p.shutdown().await?;
+
+        // close msg channel
+        log::debug!("Closing message channel.");
+        self.msg_rx.close();
 
         Ok(())
     }
@@ -274,34 +322,34 @@ impl DriaComputeNode {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::env;
+    // use super::*;
+    // use std::env;
 
-    #[tokio::test]
-    #[ignore = "run this manually"]
-    async fn test_publish_message() {
-        env::set_var("RUST_LOG", "info");
-        let _ = env_logger::try_init();
+    // #[tokio::test]
+    // #[ignore = "run this manually"]
+    // async fn test_publish_message() {
+    //     env::set_var("RUST_LOG", "info");
+    //     let _ = env_logger::try_init();
 
-        // create node
-        let cancellation = CancellationToken::new();
-        let mut node = DriaComputeNode::new(DriaComputeNodeConfig::default(), cancellation.clone())
-            .await
-            .expect("should create node");
+    //     // create node
+    //     let cancellation = CancellationToken::new();
+    //     let mut node = DriaComputeNode::new(DriaComputeNodeConfig::default(), cancellation.clone())
+    //         .await
+    //         .expect("should create node");
 
-        // launch & wait for a while for connections
-        log::info!("Waiting a bit for peer setup.");
-        tokio::select! {
-            _ = node.launch() => (),
-            _ = tokio::time::sleep(tokio::time::Duration::from_secs(20)) => cancellation.cancel(),
-        }
-        log::info!("Connected Peers:\n{:#?}", node.peers());
+    //     // launch & wait for a while for connections
+    //     log::info!("Waiting a bit for peer setup.");
+    //     tokio::select! {
+    //         _ = node.launch() => (),
+    //         _ = tokio::time::sleep(tokio::time::Duration::from_secs(20)) => cancellation.cancel(),
+    //     }
+    //     log::info!("Connected Peers:\n{:#?}", node.peers());
 
-        // publish a dummy message
-        let topic = "foo";
-        let message = DKNMessage::new("hello from the other side", topic);
-        node.subscribe(topic).expect("should subscribe");
-        node.publish(message).expect("should publish");
-        node.unsubscribe(topic).expect("should unsubscribe");
-    }
+    //     // publish a dummy message
+    //     let topic = "foo";
+    //     let message = DKNMessage::new("hello from the other side", topic);
+    //     node.subscribe(topic).expect("should subscribe");
+    //     node.publish(message).expect("should publish");
+    //     node.unsubscribe(topic).expect("should unsubscribe");
+    // }
 }

--- a/compute/src/utils/available_nodes/mod.rs
+++ b/compute/src/utils/available_nodes/mod.rs
@@ -9,7 +9,7 @@ mod statics;
 use crate::DriaNetworkType;
 
 /// Number of seconds between refreshing the available nodes.
-const DEFAULT_REFRESH_INTERVAL_SECS: u64 = 25;
+const DEFAULT_REFRESH_INTERVAL_SECS: u64 = 30 * 60; // 30 minutes
 
 impl DriaNetworkType {
     /// Returns the URL for fetching available nodes w.r.t network type.

--- a/compute/src/utils/available_nodes/mod.rs
+++ b/compute/src/utils/available_nodes/mod.rs
@@ -9,7 +9,7 @@ mod statics;
 use crate::DriaNetworkType;
 
 /// Number of seconds between refreshing the available nodes.
-const DEFAULT_REFRESH_INTERVAL_SECS: u64 = 5;
+const DEFAULT_REFRESH_INTERVAL_SECS: u64 = 25;
 
 /// Available nodes within the hybrid P2P network.
 ///

--- a/compute/src/utils/available_nodes/mod.rs
+++ b/compute/src/utils/available_nodes/mod.rs
@@ -11,6 +11,15 @@ use crate::DriaNetworkType;
 /// Number of seconds between refreshing the available nodes.
 const DEFAULT_REFRESH_INTERVAL_SECS: u64 = 25;
 
+impl DriaNetworkType {
+    /// Returns the URL for fetching available nodes w.r.t network type.
+    pub fn get_available_nodes_url(&self) -> &str {
+        match self {
+            DriaNetworkType::Community => "https://dkn.dria.co/available-nodes",
+            DriaNetworkType::Pro => "https://dkn.dria.co/sdk/available-nodes",
+        }
+    }
+}
 /// Available nodes within the hybrid P2P network.
 ///
 /// - Bootstrap: used for Kademlia DHT bootstrap.
@@ -98,11 +107,7 @@ impl AvailableNodes {
         }
 
         // make the request w.r.t network type
-        let url = match self.network_type {
-            DriaNetworkType::Community => "https://dkn.dria.co/available-nodes",
-            DriaNetworkType::Pro => "https://dkn.dria.co/sdk/available-nodes",
-        };
-        let response = reqwest::get(url).await?;
+        let response = reqwest::get(self.network_type.get_available_nodes_url()).await?;
         let response_body = response.json::<AvailableNodesApiResponse>().await?;
         self.bootstrap_nodes
             .extend(parse_vec(response_body.bootstraps).into_iter());

--- a/compute/src/utils/available_nodes/statics.rs
+++ b/compute/src/utils/available_nodes/statics.rs
@@ -1,67 +1,46 @@
 use crate::DriaNetworkType;
 use dkn_p2p::libp2p::{Multiaddr, PeerId};
 
-/// Static bootstrap nodes for the Kademlia DHT bootstrap step.
-const STATIC_BOOTSTRAP_NODES: ([&str; 4], [&str; 0]) = (
-    // community
-    [
-        "/ip4/44.206.245.139/tcp/4001/p2p/16Uiu2HAm4q3LZU2T9kgjKK4ysy6KZYKLq8KiXQyae4RHdF7uqSt4",
-        "/ip4/18.234.39.91/tcp/4001/p2p/16Uiu2HAmJqegPzwuGKWzmb5m3RdSUJ7NhEGWB5jNCd3ca9zdQ9dU",
-        "/ip4/54.242.44.217/tcp/4001/p2p/16Uiu2HAmR2sAoh9F8jT9AZup9y79Mi6NEFVUbwRvahqtWamfabkz",
-        "/ip4/52.201.242.227/tcp/4001/p2p/16Uiu2HAmFEUCy1s1gjyHfc8jey4Wd9i5bSDnyFDbWTnbrF2J3KFb",
-    ],
-    // pro
-    [],
-);
-
-/// Static relay nodes for the `P2pCircuit`.
-const STATIC_RELAY_NODES: ([&str; 4], [&str; 0]) = (
-    // community
-    [
-        "/ip4/34.201.33.141/tcp/4001/p2p/16Uiu2HAkuXiV2CQkC9eJgU6cMnJ9SMARa85FZ6miTkvn5fuHNufa",
-        "/ip4/18.232.93.227/tcp/4001/p2p/16Uiu2HAmHeGKhWkXTweHJTA97qwP81ww1W2ntGaebeZ25ikDhd4z",
-        "/ip4/54.157.219.194/tcp/4001/p2p/16Uiu2HAm7A5QVSy5FwrXAJdNNsdfNAcaYahEavyjnFouaEi22dcq",
-        "/ip4/54.88.171.104/tcp/4001/p2p/16Uiu2HAm5WP1J6bZC3aHxd7XCUumMt9txAystmbZSaMS2omHepXa",
-    ],
-    // pro
-    [],
-);
-
-/// Static RPC Peer IDs for the Admin RPC.
-const STATIC_RPC_PEER_IDS: ([&str; 0], [&str; 0]) = (
-    // community
-    [],
-    // pro
-    [],
-);
-
 impl DriaNetworkType {
-    // TODO: kind of smelly code here
+    /// Static bootstrap nodes for Kademlia.
     pub fn get_static_bootstrap_nodes(&self) -> Vec<Multiaddr> {
         match self {
-            DriaNetworkType::Community => STATIC_BOOTSTRAP_NODES.0.iter(),
-            DriaNetworkType::Pro => STATIC_BOOTSTRAP_NODES.1.iter(),
+            DriaNetworkType::Community => [
+                "/ip4/44.206.245.139/tcp/4001/p2p/16Uiu2HAm4q3LZU2T9kgjKK4ysy6KZYKLq8KiXQyae4RHdF7uqSt4",
+                "/ip4/18.234.39.91/tcp/4001/p2p/16Uiu2HAmJqegPzwuGKWzmb5m3RdSUJ7NhEGWB5jNCd3ca9zdQ9dU",
+                "/ip4/54.242.44.217/tcp/4001/p2p/16Uiu2HAmR2sAoh9F8jT9AZup9y79Mi6NEFVUbwRvahqtWamfabkz",
+                "/ip4/52.201.242.227/tcp/4001/p2p/16Uiu2HAmFEUCy1s1gjyHfc8jey4Wd9i5bSDnyFDbWTnbrF2J3KFb",
+            ].iter(),
+            DriaNetworkType::Pro => [].iter(),
         }
-        .filter_map(|s| s.parse().ok())
+        .map(|s| s.parse().expect("could not parse static bootstrap address"))
         .collect()
     }
 
+    /// Static relay nodes for the `P2pCircuit`.
     pub fn get_static_relay_nodes(&self) -> Vec<Multiaddr> {
         match self {
-            DriaNetworkType::Community => STATIC_RELAY_NODES.0.iter(),
-            DriaNetworkType::Pro => STATIC_RELAY_NODES.1.iter(),
+            DriaNetworkType::Community => [
+                "/ip4/34.201.33.141/tcp/4001/p2p/16Uiu2HAkuXiV2CQkC9eJgU6cMnJ9SMARa85FZ6miTkvn5fuHNufa",
+                "/ip4/18.232.93.227/tcp/4001/p2p/16Uiu2HAmHeGKhWkXTweHJTA97qwP81ww1W2ntGaebeZ25ikDhd4z",
+                "/ip4/54.157.219.194/tcp/4001/p2p/16Uiu2HAm7A5QVSy5FwrXAJdNNsdfNAcaYahEavyjnFouaEi22dcq",
+                "/ip4/54.88.171.104/tcp/4001/p2p/16Uiu2HAm5WP1J6bZC3aHxd7XCUumMt9txAystmbZSaMS2omHepXa",
+            ].iter(),
+            DriaNetworkType::Pro => [].iter(),
         }
-        .filter_map(|s| s.parse().ok())
+        .map(|s| s.parse().expect("could not parse static relay address"))
         .collect()
     }
 
+    /// Static RPC Peer IDs for the Admin RPC.
     pub fn get_static_rpc_peer_ids(&self) -> Vec<PeerId> {
-        match self {
-            DriaNetworkType::Community => STATIC_RPC_PEER_IDS.0.iter(),
-            DriaNetworkType::Pro => STATIC_RPC_PEER_IDS.1.iter(),
-        }
-        .filter_map(|s| s.parse().ok())
-        .collect()
+        // match self {
+        //     DriaNetworkType::Community => [].iter(),
+        //     DriaNetworkType::Pro => [].iter(),
+        // }
+        // .filter_map(|s| s.parse().ok())
+        // .collect()
+        vec![]
     }
 }
 

--- a/compute/src/utils/available_nodes/statics.rs
+++ b/compute/src/utils/available_nodes/statics.rs
@@ -1,0 +1,68 @@
+use crate::DriaNetworkType;
+use dkn_p2p::libp2p::{Multiaddr, PeerId};
+
+/// Static bootstrap nodes for the Kademlia DHT bootstrap step.
+const STATIC_BOOTSTRAP_NODES: ([&str; 4], [&str; 0]) = (
+    // community
+    [
+        "/ip4/44.206.245.139/tcp/4001/p2p/16Uiu2HAm4q3LZU2T9kgjKK4ysy6KZYKLq8KiXQyae4RHdF7uqSt4",
+        "/ip4/18.234.39.91/tcp/4001/p2p/16Uiu2HAmJqegPzwuGKWzmb5m3RdSUJ7NhEGWB5jNCd3ca9zdQ9dU",
+        "/ip4/54.242.44.217/tcp/4001/p2p/16Uiu2HAmR2sAoh9F8jT9AZup9y79Mi6NEFVUbwRvahqtWamfabkz",
+        "/ip4/52.201.242.227/tcp/4001/p2p/16Uiu2HAmFEUCy1s1gjyHfc8jey4Wd9i5bSDnyFDbWTnbrF2J3KFb",
+    ],
+    // pro
+    [],
+);
+
+/// Static relay nodes for the `P2pCircuit`.
+const STATIC_RELAY_NODES: ([&str; 4], [&str; 0]) = (
+    // community
+    [
+        "/ip4/34.201.33.141/tcp/4001/p2p/16Uiu2HAkuXiV2CQkC9eJgU6cMnJ9SMARa85FZ6miTkvn5fuHNufa",
+        "/ip4/18.232.93.227/tcp/4001/p2p/16Uiu2HAmHeGKhWkXTweHJTA97qwP81ww1W2ntGaebeZ25ikDhd4z",
+        "/ip4/54.157.219.194/tcp/4001/p2p/16Uiu2HAm7A5QVSy5FwrXAJdNNsdfNAcaYahEavyjnFouaEi22dcq",
+        "/ip4/54.88.171.104/tcp/4001/p2p/16Uiu2HAm5WP1J6bZC3aHxd7XCUumMt9txAystmbZSaMS2omHepXa",
+    ],
+    // pro
+    [],
+);
+
+/// Static RPC Peer IDs for the Admin RPC.
+const STATIC_RPC_PEER_IDS: ([&str; 0], [&str; 0]) = (
+    // community
+    [],
+    // pro
+    [],
+);
+
+impl DriaNetworkType {
+    // TODO: kind of smelly code here
+    pub fn get_static_bootstrap_nodes(&self) -> Vec<Multiaddr> {
+        match self {
+            DriaNetworkType::Community => STATIC_BOOTSTRAP_NODES.0.iter(),
+            DriaNetworkType::Pro => STATIC_BOOTSTRAP_NODES.1.iter(),
+        }
+        .filter_map(|s| s.parse().ok())
+        .collect()
+    }
+
+    pub fn get_static_relay_nodes(&self) -> Vec<Multiaddr> {
+        match self {
+            DriaNetworkType::Community => STATIC_RELAY_NODES.0.iter(),
+            DriaNetworkType::Pro => STATIC_RELAY_NODES.1.iter(),
+        }
+        .filter_map(|s| s.parse().ok())
+        .collect()
+    }
+
+    pub fn get_static_rpc_peer_ids(&self) -> Vec<PeerId> {
+        match self {
+            DriaNetworkType::Community => STATIC_RPC_PEER_IDS.0.iter(),
+            DriaNetworkType::Pro => STATIC_RPC_PEER_IDS.1.iter(),
+        }
+        .filter_map(|s| s.parse().ok())
+        .collect()
+    }
+}
+
+// help me

--- a/compute/src/utils/message.rs
+++ b/compute/src/utils/message.rs
@@ -49,9 +49,7 @@ impl DKNMessage {
             payload: BASE64_STANDARD.encode(data),
             topic: topic.to_string(),
             version: DRIA_COMPUTE_NODE_VERSION.to_string(),
-            identity: dkn_p2p::P2P_IDENTITY_PREFIX
-                .trim_end_matches('/')
-                .to_string(),
+            identity: String::default(),
             timestamp: get_current_time_nanos(),
         }
     }
@@ -68,6 +66,12 @@ impl DKNMessage {
 
         // create the actual message with this signed data
         Self::new(signed_data, topic)
+    }
+
+    /// Sets the identity of the message.
+    pub fn with_identity(mut self, identity: String) -> Self {
+        self.identity = identity;
+        self
     }
 
     /// Decodes the base64 payload into bytes.
@@ -102,11 +106,11 @@ impl DKNMessage {
         let (signature_hex_bytes, body) =
             (&data[..SIGNATURE_SIZE_HEX - 2], &data[SIGNATURE_SIZE_HEX..]);
         let signature_bytes =
-            hex::decode(signature_hex_bytes).wrap_err("Could not decode signature hex")?;
+            hex::decode(signature_hex_bytes).wrap_err("could not decode signature hex")?;
 
         // now obtain the signature itself
         let signature = Signature::parse_standard_slice(&signature_bytes)
-            .wrap_err("Could not parse signature bytes")?;
+            .wrap_err("could not parse signature bytes")?;
 
         // verify signature w.r.t the body and the given public key
         let digest = Message::parse(&sha256hash(body));

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -31,6 +31,8 @@ libp2p-identity = { version = "0.2.9", features = ["secp256k1"] }
 log.workspace = true
 eyre.workspace = true
 
+tokio-util.workspace = true
+tokio.workspace = true
+
 [dev-dependencies]
 env_logger.workspace = true
-tokio.workspace = true

--- a/p2p/README.md
+++ b/p2p/README.md
@@ -12,6 +12,53 @@ dkn-p2p = { git = "https://github.com/firstbatchxyz/dkn-compute-node" }
 
 ## Usage
 
+The P2P client is expected to be run within a separate thread, and it has two types of interactions:
+
+- **Events**: When a message is received within the Swarm event handler, it is returned via a `mpsc` channel. Here, the p2p is `Sender` and your application must be the `Receiver`. The client handles many events, and only sends GossipSub message receipts via this channel so that the application can handle them however they would like.
+
+```mermaid
+sequenceDiagram
+  actor A as Application
+  actor P as P2P Client
+
+  note over P: e_tx
+  note over A: e_rx
+
+  loop event loop
+  activate P
+    note over A: e_rx.wait()
+    P ->> A: e_tx.send(message)
+    deactivate P
+
+    note over A: handle message
+  end
+
+```
+
+- **Commands**: To call functions within this thread-scoped client, functions must be remotely called via the command `mpsc` channel. Here, p2p is `Receiver` and your application will be the `Sender` (we provide the commander client as well). While making a function call, a `oneshot` channel is created and its `Sender` is provided to the commander, kind of like a callback, and the caller waits as the `Receiver` for this call.
+
+```mermaid
+sequenceDiagram
+  actor C as P2P Commander
+  actor P as P2P Client
+  note over C: c_tx
+  activate C
+  note over P: c_rx
+
+  note over P: c_rx.wait()
+  note over C: o_tx, o_rx := oneshot()
+  C ->> P: c_tx.send(input, o_tx)
+  deactivate C
+  activate P
+  note over C: o_rx.wait()
+  P ->> C: o_tx.send(output)
+  deactivate P
+```
+
+<!--
+
+FIXME: REMOVE COMMENTS
+
 You can create the client as follows:
 
 ```rs
@@ -38,4 +85,4 @@ let version = "0.2";
 let mut client = DriaP2PClient::new(keypair, addr, &bootstraps, &relays, "0.2")?;
 ```
 
-Then, you can use its underlying functions, such as `subscribe`, `process_events` and `unsubscribe`. In particular, `process_events` handles all p2p events and returns a GossipSub message when it is received.
+Then, you can use its underlying functions, such as `subscribe`, `process_events` and `unsubscribe`. In particular, `process_events` handles all p2p events and returns a GossipSub message when it is received. -->

--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -49,7 +49,7 @@ fn create_connection_limits_behaviour() -> connection_limits::Behaviour {
 
     /// Number of established outgoing connections limit, this is directly correlated to peer count
     /// so limiting this will cause a limitation on peers as well.
-    const EST_OUTGOING_LIMIT: u32 = 450;
+    const EST_OUTGOING_LIMIT: u32 = 300;
 
     let limits =
         ConnectionLimits::default().with_max_established_outgoing(Some(EST_OUTGOING_LIMIT));

--- a/p2p/src/client.rs
+++ b/p2p/src/client.rs
@@ -1,41 +1,44 @@
-use super::*;
-use eyre::{Context, Result};
+use eyre::Result;
 use libp2p::futures::StreamExt;
-use libp2p::gossipsub::{
-    Message, MessageAcceptance, MessageId, PublishError, SubscriptionError, TopicHash,
-};
+use libp2p::gossipsub::{Message, MessageId};
 use libp2p::kad::{GetClosestPeersError, GetClosestPeersOk, QueryResult};
-use libp2p::swarm::{dial_opts::DialOpts, NetworkInfo, SwarmEvent};
+use libp2p::swarm::SwarmEvent;
 use libp2p::{autonat, gossipsub, identify, kad, multiaddr::Protocol, noise, tcp, yamux};
 use libp2p::{Multiaddr, PeerId, Swarm, SwarmBuilder};
 use libp2p_identity::Keypair;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use tokio::sync::mpsc;
 
-/// P2P client, exposes a simple interface to handle P2P communication.
+use crate::behaviour::{DriaBehaviour, DriaBehaviourEvent};
+use crate::DriaP2PProtocol;
+
+use super::commands::DriaP2PCommand;
+use super::DriaP2PCommander;
+
+/// Peer-to-peer client for Dria Knowledge Network.
 pub struct DriaP2PClient {
     /// `Swarm` instance, everything is accesses through this one.
     swarm: Swarm<DriaBehaviour>,
-    /// Peer count for All and Mesh peers.
-    ///
-    /// Mesh usually contains much fewer peers than All, as they are the ones
-    /// used for actual gossipping.
-    peer_count: (usize, usize),
-    /// Last time the peer count was refreshed.
-    peer_last_refreshed: Instant,
     /// Dria protocol, used for identifying the client.
     protocol: DriaP2PProtocol,
+    /// Message sender / transmitter.
+    msg_tx: mpsc::Sender<(PeerId, MessageId, Message)>,
+    /// Command receiver.
+    cmd_rx: mpsc::Receiver<DriaP2PCommand>,
 }
 
+// TODO: make all these configurable
 /// Number of seconds before an idle connection is closed.
 const IDLE_CONNECTION_TIMEOUT_SECS: u64 = 60;
-
-/// Number of seconds between refreshing the Kademlia DHT.
-const PEER_REFRESH_INTERVAL_SECS: u64 = 30;
+/// Buffer size for command channel.
+const COMMAND_CHANNEL_BUFSIZE: usize = 256;
+/// Buffer size for events channel.
+const MSG_CHANNEL_BUFSIZE: usize = 256;
 
 impl DriaP2PClient {
     /// Creates a new P2P client with the given keypair and listen address.
     ///
-    /// Can provide a list of bootstrap and relay nodes to connect to as well at the start.
+    /// Can provide a list of bootstrap and relay nodes to connect to as well at the start, and RPC addresses to dial preemptively.
     ///
     /// The `version` is used to create the protocol strings for the client, and its very important that
     /// they match with the clients existing within the network.
@@ -44,8 +47,13 @@ impl DriaP2PClient {
         listen_addr: Multiaddr,
         bootstraps: impl Iterator<Item = Multiaddr>,
         relays: impl Iterator<Item = Multiaddr>,
+        rpcs: impl Iterator<Item = Multiaddr>,
         protocol: DriaP2PProtocol,
-    ) -> Result<Self> {
+    ) -> Result<(
+        DriaP2PClient,
+        DriaP2PCommander,
+        mpsc::Receiver<(PeerId, MessageId, Message)>,
+    )> {
         // this is our peerId
         let node_peerid = keypair.public().to_peer_id();
         log::info!("Compute node peer address: {}", node_peerid);
@@ -107,150 +115,182 @@ impl DriaP2PClient {
         // listen on all interfaces for incoming connections
         log::info!("Listening p2p network on: {}", listen_addr);
         swarm.listen_on(listen_addr)?;
-
         for addr in relays {
             log::info!("Listening to relay: {}", addr);
             swarm.listen_on(addr.clone().with(Protocol::P2pCircuit))?;
         }
 
-        Ok(Self {
-            swarm,
-            peer_count: (0, 0),
-            peer_last_refreshed: Instant::now(),
-            protocol,
-        })
-    }
-
-    /// Returns a reference to the underlying P2P protocol.
-    pub fn protocol(&self) -> &DriaP2PProtocol {
-        &self.protocol
-    }
-
-    /// Returns the network information, such as the number of
-    /// incoming and outgoing connections.
-    pub fn network_info(&self) -> NetworkInfo {
-        self.swarm.network_info()
-    }
-
-    /// Subscribe to a topic.
-    pub fn subscribe(&mut self, topic_name: &str) -> Result<bool, SubscriptionError> {
-        log::debug!("Subscribing to {}", topic_name);
-
-        let topic = gossipsub::IdentTopic::new(topic_name);
-        self.swarm.behaviour_mut().gossipsub.subscribe(&topic)
-    }
-
-    /// Unsubscribe from a topic.
-    pub fn unsubscribe(&mut self, topic_name: &str) -> Result<bool, PublishError> {
-        log::debug!("Unsubscribing from {}", topic_name);
-
-        let topic = gossipsub::IdentTopic::new(topic_name);
-        self.swarm.behaviour_mut().gossipsub.unsubscribe(&topic)
-    }
-
-    /// Publish a message to a topic.
-    ///
-    /// Returns the message ID.
-    pub fn publish(
-        &mut self,
-        topic_name: &str,
-        message_bytes: Vec<u8>,
-    ) -> Result<MessageId, PublishError> {
-        log::debug!("Publishing message to topic: {}", topic_name);
-
-        let topic = gossipsub::IdentTopic::new(topic_name);
-        let message_id = self
-            .swarm
-            .behaviour_mut()
-            .gossipsub
-            .publish(topic, message_bytes)?;
-
-        Ok(message_id)
-    }
-
-    /// Validates a GossipSub message for propagation.
-    ///
-    /// - `Accept`: Accept the message and propagate it.
-    /// - `Reject`: Reject the message and do not propagate it, with penalty to `propagation_source`.
-    /// - `Ignore`: Ignore the message and do not propagate it, without any penalties.
-    ///
-    /// See [`validate_messages`](https://docs.rs/libp2p-gossipsub/latest/libp2p_gossipsub/struct.Config.html#method.validate_messages)
-    /// and [`report_message_validation_result`](https://docs.rs/libp2p-gossipsub/latest/libp2p_gossipsub/struct.Behaviour.html#method.report_message_validation_result) for more details.
-    pub fn validate_message(
-        &mut self,
-        msg_id: &MessageId,
-        propagation_source: &PeerId,
-        acceptance: MessageAcceptance,
-    ) -> Result<()> {
-        log::trace!("Validating message ({}): {:?}", msg_id, acceptance);
-
-        let msg_was_in_cache = self
-            .swarm
-            .behaviour_mut()
-            .gossipsub
-            .report_message_validation_result(msg_id, propagation_source, acceptance)?;
-
-        if !msg_was_in_cache {
-            log::debug!("Validated message was not in cache.");
+        // dial rpc nodes
+        for rpc_addr in rpcs {
+            log::info!("Dialing RPC node: {}", rpc_addr);
+            swarm.dial(rpc_addr)?;
         }
-        Ok(())
+
+        // create commander
+        let (cmd_tx, cmd_rx) = mpsc::channel(COMMAND_CHANNEL_BUFSIZE);
+        let commander = DriaP2PCommander::new(cmd_tx, protocol.clone());
+
+        // create p2p client itself
+        let (msg_tx, msg_rx) = mpsc::channel(MSG_CHANNEL_BUFSIZE);
+        let client = Self {
+            swarm,
+            protocol,
+            msg_tx,
+            cmd_rx,
+        };
+
+        Ok((client, commander, msg_rx))
     }
 
-    /// Returns the list of connected peers within Gossipsub, with a list of subscribed topic hashes by each peer.
-    pub fn peers(&self) -> Vec<(&PeerId, Vec<&TopicHash>)> {
-        self.swarm.behaviour().gossipsub.all_peers().collect()
-    }
-
-    /// Dials a given peer.
-    pub fn dial(&mut self, peer_id: impl Into<DialOpts>) -> Result<()> {
-        self.swarm.dial(peer_id).wrap_err("could not dial")
-    }
-
-    /// Listens to the Swarm for incoming messages.
+    /// Waits for swarm events and Node commands at the same time.
     ///
-    /// This method should be called in a loop to keep the client running.
-    /// When a GossipSub message is received, it will be returned.
-    pub async fn process_events(&mut self) -> (PeerId, MessageId, Message) {
+    /// To terminate, the command channel must be closed.
+    pub async fn run(mut self) {
+        // FIXME: use refresh peers somewhere
         loop {
-            // refresh peers
-            self.refresh_peer_counts().await;
-
-            // wait for next event
-            match self.swarm.select_next_some().await {
-                // notifies that a kademlia event has been produced.
-                SwarmEvent::Behaviour(DriaBehaviourEvent::Kademlia(
-                    kad::Event::OutboundQueryProgressed {
-                        result: QueryResult::GetClosestPeers(result),
-                        ..
+            tokio::select! {
+                event = self.swarm.select_next_some() => self.handle_event(event).await,
+                command = self.cmd_rx.recv() => match command {
+                    Some(c) => self.handle_command(c).await,
+                    // channel closed, thus shutting down the network event loop
+                    None=>  {
+                        log::warn!("Closing P2P client.");
+                        return
                     },
-                )) => self.handle_closest_peers_result(result),
-                // notifies that a kademlia event has been produced.
-                SwarmEvent::Behaviour(DriaBehaviourEvent::Identify(
-                    identify::Event::Received { peer_id, info, .. },
-                )) => self.handle_identify_event(peer_id, info),
-                SwarmEvent::Behaviour(DriaBehaviourEvent::Gossipsub(
-                    gossipsub::Event::Message {
-                        propagation_source: peer_id,
-                        message_id,
-                        message,
-                    },
-                )) => {
-                    return (peer_id, message_id, message);
-                }
-                SwarmEvent::Behaviour(DriaBehaviourEvent::Autonat(
-                    autonat::Event::StatusChanged { old, new },
-                )) => {
-                    log::warn!("AutoNAT status changed from {:?} to {:?}", old, new);
-                }
-                SwarmEvent::NewListenAddr { address, .. } => {
-                    log::warn!("Local node is listening on {}", address);
-                }
-                SwarmEvent::ExternalAddrConfirmed { address } => {
-                    // this is usually the external address via relay
-                    log::info!("External address confirmed: {}", address);
-                }
-                event => log::trace!("Unhandled Swarm Event: {:?}", event),
+                },
             }
+        }
+    }
+
+    /// Handles a single command, which originates from `DriaP2PCommander`.
+    pub async fn handle_command(&mut self, command: DriaP2PCommand) {
+        match command {
+            DriaP2PCommand::Dial { peer_id, sender } => {
+                let _ = sender.send(self.swarm.dial(peer_id));
+            }
+            DriaP2PCommand::NetworkInfo { sender } => {
+                let _ = sender.send(self.swarm.network_info());
+            }
+            DriaP2PCommand::Subscribe { topic, sender } => {
+                let _ = sender.send(
+                    self.swarm
+                        .behaviour_mut()
+                        .gossipsub
+                        .subscribe(&gossipsub::IdentTopic::new(topic)),
+                );
+            }
+            DriaP2PCommand::Unsubscribe { topic, sender } => {
+                let _ = sender.send(
+                    self.swarm
+                        .behaviour_mut()
+                        .gossipsub
+                        .unsubscribe(&gossipsub::IdentTopic::new(topic)),
+                );
+            }
+            DriaP2PCommand::Publish {
+                topic,
+                data,
+                sender,
+            } => {
+                let _ = sender.send(
+                    self.swarm
+                        .behaviour_mut()
+                        .gossipsub
+                        .publish(gossipsub::IdentTopic::new(topic), data),
+                );
+            }
+            DriaP2PCommand::ValidateMessage {
+                msg_id,
+                propagation_source,
+                acceptance,
+                sender,
+            } => {
+                let _ = sender.send(
+                    self.swarm
+                        .behaviour_mut()
+                        .gossipsub
+                        .report_message_validation_result(&msg_id, &propagation_source, acceptance),
+                );
+            }
+            DriaP2PCommand::Refresh { sender } => {
+                let _ = sender.send(
+                    self.swarm
+                        .behaviour_mut()
+                        .kademlia
+                        .get_closest_peers(PeerId::random()),
+                );
+            }
+            DriaP2PCommand::Peers { sender } => {
+                let mesh = self
+                    .swarm
+                    .behaviour()
+                    .gossipsub
+                    .all_mesh_peers()
+                    .cloned()
+                    .collect();
+                let all = self
+                    .swarm
+                    .behaviour()
+                    .gossipsub
+                    .all_peers()
+                    .map(|(p, _)| p)
+                    .cloned()
+                    .collect();
+                let _ = sender.send((mesh, all));
+            }
+            DriaP2PCommand::PeerCounts { sender } => {
+                let mesh = self.swarm.behaviour().gossipsub.all_mesh_peers().count();
+                let all = self.swarm.behaviour().gossipsub.all_peers().count();
+                let _ = sender.send((mesh, all));
+            }
+            DriaP2PCommand::Shutdown { sender } => {
+                self.cmd_rx.close();
+                let _ = sender.send(());
+            }
+        }
+    }
+
+    /// Handles a single event from the `swarm` stream.
+    pub async fn handle_event(&mut self, event: SwarmEvent<DriaBehaviourEvent>) {
+        match event {
+            // this is the main event we are interested in, it will send the message via channel
+            SwarmEvent::Behaviour(DriaBehaviourEvent::Gossipsub(gossipsub::Event::Message {
+                propagation_source: peer_id,
+                message_id,
+                message,
+            })) => {
+                if let Err(e) = self.msg_tx.send((peer_id, message_id, message)).await {
+                    log::error!("Error sending message: {:?}", e);
+                }
+            }
+
+            SwarmEvent::Behaviour(DriaBehaviourEvent::Kademlia(
+                kad::Event::OutboundQueryProgressed {
+                    result: QueryResult::GetClosestPeers(result),
+                    ..
+                },
+            )) => self.handle_closest_peers_result(result),
+            SwarmEvent::Behaviour(DriaBehaviourEvent::Identify(identify::Event::Received {
+                peer_id,
+                info,
+                ..
+            })) => self.handle_identify_event(peer_id, info),
+
+            SwarmEvent::Behaviour(DriaBehaviourEvent::Autonat(autonat::Event::StatusChanged {
+                old,
+                new,
+            })) => {
+                log::warn!("AutoNAT status changed from {:?} to {:?}", old, new);
+            }
+
+            SwarmEvent::NewListenAddr { address, .. } => {
+                log::warn!("Local node is listening on {}", address);
+            }
+            SwarmEvent::ExternalAddrConfirmed { address } => {
+                // this is usually the external address via relay
+                log::info!("External address confirmed: {}", address);
+            }
+            event => log::trace!("Unhandled Swarm Event: {:?}", event),
         }
     }
 
@@ -344,55 +384,6 @@ impl DriaP2PClient {
                 log::info!(
                     "Kademlia: Query timed out with {} closest peers.",
                     peers.len()
-                );
-            }
-        }
-    }
-
-    /// Does a random-walk over DHT and updates peer counts as needed.
-    /// Keeps track of the last time the peer count was refreshed.
-    ///
-    /// Should be called in a loop.
-    ///
-    /// Returns: (All Peer Count, Mesh Peer Count)
-    pub async fn refresh_peer_counts(&mut self) {
-        if self.peer_last_refreshed.elapsed() > Duration::from_secs(PEER_REFRESH_INTERVAL_SECS) {
-            let random_peer = PeerId::random();
-            self.swarm
-                .behaviour_mut()
-                .kademlia
-                .get_closest_peers(random_peer);
-            self.peer_last_refreshed = Instant::now();
-
-            // get peer count
-            let gossipsub = &self.swarm.behaviour().gossipsub;
-            let num_peers = gossipsub.all_peers().count();
-            let num_mesh_peers = gossipsub.all_mesh_peers().count();
-
-            // print peer counts
-            log::info!("Peer Count (mesh/all): {} / {}", num_mesh_peers, num_peers);
-
-            // print peers themselves if the count has changed
-            if num_peers != self.peer_count.0 || num_mesh_peers != self.peer_count.1 {
-                self.peer_count = (num_peers, num_mesh_peers);
-
-                log::debug!(
-                    "All Peers:\n{}",
-                    gossipsub
-                        .all_peers()
-                        .enumerate()
-                        .map(|(i, (p, _))| format!("{:#3}: {}", i, p))
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                );
-                log::debug!(
-                    "Mesh Peers:\n{}",
-                    gossipsub
-                        .all_mesh_peers()
-                        .enumerate()
-                        .map(|(i, p)| format!("{:#3}: {}", i, p))
-                        .collect::<Vec<_>>()
-                        .join("\n")
                 );
             }
         }

--- a/p2p/src/commands.rs
+++ b/p2p/src/commands.rs
@@ -1,0 +1,259 @@
+use eyre::{Context, Result};
+use libp2p::{gossipsub, kad, swarm, Multiaddr, PeerId};
+use tokio::sync::{mpsc, oneshot};
+
+use crate::DriaP2PProtocol;
+
+#[derive(Debug)]
+pub enum DriaP2PCommand {
+    /// Returns the network information, such as the number of incoming and outgoing connections.
+    NetworkInfo {
+        sender: oneshot::Sender<swarm::NetworkInfo>,
+    },
+    /// Make a Kademlia closest-peers query.
+    Refresh {
+        sender: oneshot::Sender<kad::QueryId>,
+    },
+    /// Get peers (mesh & all) of the GossipSub pool.
+    Peers {
+        sender: oneshot::Sender<(Vec<PeerId>, Vec<PeerId>)>,
+    },
+    /// Get peers counts (mesh & all) of the GossipSub pool.
+    PeerCounts {
+        sender: oneshot::Sender<(usize, usize)>,
+    },
+    /// Dial a peer.
+    Dial {
+        peer_id: Multiaddr,
+        sender: oneshot::Sender<Result<(), swarm::DialError>>,
+    },
+    /// Subscribe to a topic.
+    Subscribe {
+        topic: String,
+        sender: oneshot::Sender<Result<bool, gossipsub::SubscriptionError>>,
+    },
+    /// Unsubscribe from a topic.
+    Unsubscribe {
+        topic: String,
+        sender: oneshot::Sender<Result<bool, gossipsub::PublishError>>,
+    },
+    /// Publishes a message to a topic, returns the message ID.
+    Publish {
+        topic: String,
+        data: Vec<u8>,
+        sender: oneshot::Sender<Result<gossipsub::MessageId, gossipsub::PublishError>>,
+    },
+    /// Validates a GossipSub message for propagation, returns whether the message existed in cache.
+    ///
+    /// - `Accept`: Accept the message and propagate it.
+    /// - `Reject`: Reject the message and do not propagate it, with penalty to `propagation_source`.
+    /// - `Ignore`: Ignore the message and do not propagate it, without any penalties.
+    ///
+    /// See [`validate_messages`](https://docs.rs/libp2p-gossipsub/latest/libp2p_gossipsub/struct.Config.html#method.validate_messages)
+    /// and [`report_message_validation_result`](https://docs.rs/libp2p-gossipsub/latest/libp2p_gossipsub/struct.Behaviour.html#method.report_message_validation_result) for more details.
+    ValidateMessage {
+        msg_id: gossipsub::MessageId,
+        propagation_source: PeerId,
+        acceptance: gossipsub::MessageAcceptance,
+        sender: oneshot::Sender<Result<bool, gossipsub::PublishError>>,
+    },
+    /// Shutsdown the client, closes the command channel.
+    Shutdown { sender: oneshot::Sender<()> },
+}
+
+pub struct DriaP2PCommander {
+    sender: mpsc::Sender<DriaP2PCommand>,
+    protocol: DriaP2PProtocol,
+}
+
+impl DriaP2PCommander {
+    pub fn new(sender: mpsc::Sender<DriaP2PCommand>, protocol: DriaP2PProtocol) -> Self {
+        Self { sender, protocol }
+    }
+
+    /// Returns a reference to the protocol.
+    pub fn protocol(&self) -> &DriaP2PProtocol {
+        &self.protocol
+    }
+
+    /// Returns the network information, such as the number of
+    /// incoming and outgoing connections.
+    pub async fn network_info(&self) -> Result<swarm::NetworkInfo> {
+        let (sender, receiver) = oneshot::channel();
+
+        self.sender
+            .send(DriaP2PCommand::NetworkInfo { sender })
+            .await
+            .wrap_err("could not send")?;
+
+        receiver.await.wrap_err("could not receive")
+    }
+
+    /// Subscribe to a topic.
+    pub async fn subscribe(&self, topic_name: &str) -> Result<bool> {
+        let (sender, receiver) = oneshot::channel();
+
+        log::debug!("Subscribing to {}", topic_name);
+        self.sender
+            .send(DriaP2PCommand::Subscribe {
+                topic: topic_name.to_string(),
+                sender,
+            })
+            .await
+            .wrap_err("could not send")?;
+
+        receiver
+            .await
+            .wrap_err("could not receive")?
+            .wrap_err("could not subscribe")
+    }
+
+    /// Unsubscribe from a topic.
+    pub async fn unsubscribe(&self, topic_name: &str) -> Result<bool> {
+        let (sender, receiver) = oneshot::channel();
+
+        log::debug!("Unsubscribing from {}", topic_name);
+        self.sender
+            .send(DriaP2PCommand::Unsubscribe {
+                topic: topic_name.to_string(),
+                sender,
+            })
+            .await
+            .wrap_err("could not send")?;
+
+        receiver
+            .await
+            .wrap_err("could not receive")?
+            .wrap_err("could not unsubscribe")
+    }
+
+    /// Publish a message to a topic.
+    ///
+    /// Returns the message ID.
+    pub async fn publish(
+        &mut self,
+        topic_name: &str,
+        data: Vec<u8>,
+    ) -> Result<gossipsub::MessageId> {
+        let (sender, receiver) = oneshot::channel();
+
+        log::debug!("Publishing message to topic: {}", topic_name);
+        self.sender
+            .send(DriaP2PCommand::Publish {
+                topic: topic_name.to_string(),
+                data,
+                sender,
+            })
+            .await
+            .wrap_err("could not send")?;
+
+        receiver
+            .await
+            .wrap_err("could not receive")?
+            .wrap_err("could not publish")
+    }
+
+    /// Dials a given peer.
+    pub async fn dial(&mut self, peer_id: Multiaddr) -> Result<()> {
+        let (sender, receiver) = oneshot::channel();
+
+        self.sender
+            .send(DriaP2PCommand::Dial { peer_id, sender })
+            .await
+            .wrap_err("could not send")?;
+
+        receiver
+            .await
+            .wrap_err("could not receive")?
+            .wrap_err("could not dial")
+    }
+
+    /// Validates a GossipSub message for propagation.
+    ///
+    /// - `Accept`: Accept the message and propagate it.
+    /// - `Reject`: Reject the message and do not propagate it, with penalty to `propagation_source`.
+    /// - `Ignore`: Ignore the message and do not propagate it, without any penalties.
+    ///
+    /// See [`validate_messages`](https://docs.rs/libp2p-gossipsub/latest/libp2p_gossipsub/struct.Config.html#method.validate_messages)
+    /// and [`report_message_validation_result`](https://docs.rs/libp2p-gossipsub/latest/libp2p_gossipsub/struct.Behaviour.html#method.report_message_validation_result) for more details.
+    pub async fn validate_message(
+        &mut self,
+        msg_id: &gossipsub::MessageId,
+        propagation_source: &PeerId,
+        acceptance: gossipsub::MessageAcceptance,
+    ) -> Result<()> {
+        let (sender, receiver) = oneshot::channel();
+
+        log::trace!("Validating message ({}): {:?}", msg_id, acceptance);
+        self.sender
+            .send(DriaP2PCommand::ValidateMessage {
+                msg_id: msg_id.clone(),
+                propagation_source: propagation_source.clone(),
+                acceptance,
+                sender,
+            })
+            .await
+            .wrap_err("could not send")?;
+
+        let msg_was_in_cache = receiver
+            .await
+            .wrap_err("could not receive")?
+            .wrap_err("could not unsubscribe")?;
+
+        if !msg_was_in_cache {
+            log::debug!("Validated message was not in cache.");
+        }
+
+        Ok(())
+    }
+
+    /// Refreshes the Kademlia DHT using a closest peer query over a random peer.
+    pub async fn refresh(&mut self) -> Result<kad::QueryId> {
+        let (sender, receiver) = oneshot::channel();
+
+        self.sender
+            .send(DriaP2PCommand::Refresh { sender })
+            .await
+            .wrap_err("could not send")?;
+
+        receiver.await.wrap_err("could not receive")
+    }
+
+    /// Get peers (mesh & all) of the GossipSub pool.
+    /// Returns a tuple of the mesh peers and all peers.
+    pub async fn peers(&self) -> Result<(Vec<PeerId>, Vec<PeerId>)> {
+        let (sender, receiver) = oneshot::channel();
+
+        self.sender
+            .send(DriaP2PCommand::Peers { sender })
+            .await
+            .wrap_err("could not send")?;
+
+        receiver.await.wrap_err("could not receive")
+    }
+
+    /// Get peers counts (mesh & all) of the GossipSub pool.
+    /// Returns a tuple of the mesh peer count and all peer count.
+    pub async fn peer_counts(&self) -> Result<(usize, usize)> {
+        let (sender, receiver) = oneshot::channel();
+
+        self.sender
+            .send(DriaP2PCommand::PeerCounts { sender })
+            .await
+            .wrap_err("could not send")?;
+
+        receiver.await.wrap_err("could not receive")
+    }
+
+    /// Sends a shutdown signal to the client.
+    pub async fn shutdown(&mut self) -> Result<()> {
+        let (sender, receiver) = oneshot::channel();
+
+        self.sender
+            .send(DriaP2PCommand::Shutdown { sender })
+            .await
+            .wrap_err("could not send")?;
+
+        receiver.await.wrap_err("could not receive")
+    }
+}

--- a/p2p/src/commands.rs
+++ b/p2p/src/commands.rs
@@ -233,7 +233,7 @@ impl DriaP2PCommander {
     }
 
     /// Get peers counts (mesh & all) of the GossipSub pool.
-    /// Returns a tuple of the mesh peer count and all peer count.
+    /// Returns a tuple of the mesh peers count and all peers count.
     pub async fn peer_counts(&self) -> Result<(usize, usize)> {
         let (sender, receiver) = oneshot::channel();
 

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -6,11 +6,8 @@ use behaviour::{DriaBehaviour, DriaBehaviourEvent};
 mod client;
 pub use client::DriaP2PClient;
 
-/// Prefix for Kademlia protocol, must start with `/`!
-pub const P2P_KADEMLIA_PREFIX: &str = "/dria/kad/";
-
-/// Prefix for Identity protocol string.
-pub const P2P_IDENTITY_PREFIX: &str = "dria/";
+mod protocol;
+pub use protocol::DriaP2PProtocol;
 
 // re-exports
 pub use libp2p;

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1,10 +1,12 @@
 mod transform;
 
 mod behaviour;
-use behaviour::{DriaBehaviour, DriaBehaviourEvent};
 
 mod client;
 pub use client::DriaP2PClient;
+
+mod commands;
+pub use commands::{DriaP2PCommand, DriaP2PCommander};
 
 mod protocol;
 pub use protocol::DriaP2PProtocol;

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -20,6 +20,12 @@ pub struct DriaP2PProtocol {
     pub kademlia: StreamProtocol,
 }
 
+impl std::fmt::Display for DriaP2PProtocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.identity)
+    }
+}
+
 impl Default for DriaP2PProtocol {
     /// Creates a new instance of the protocol with the default name `dria`.
     fn default() -> Self {

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -1,0 +1,116 @@
+use libp2p::StreamProtocol;
+use std::env;
+
+#[derive(Clone, Debug)]
+pub struct DriaP2PProtocol {
+    /// Main protocol name, e.g. `dria`.
+    pub name: String,
+    /// Version of the protocol, e.g. `0.2`.
+    /// By default, this is set to the current `major.minor` version of the crate.
+    pub version: String,
+    /// Identity protocol string to be used for the Identity behaviour.
+    ///
+    /// This is usually `{name}/{version}`.
+    pub identity: String,
+    /// Kademlia protocol, must match with other peers in the network.
+    ///
+    /// This is usually `/{name}/kad/{version}`, notice the `/` at the start
+    /// which is mandatory for a `StreamProtocol`.
+    ///
+    pub kademlia: StreamProtocol,
+}
+
+impl Default for DriaP2PProtocol {
+    /// Creates a new instance of the protocol with the default name `dria`.
+    fn default() -> Self {
+        Self::new_major_minor("dria")
+    }
+}
+
+impl DriaP2PProtocol {
+    /// Creates a new instance of the protocol with the given `name` and `version`.
+    pub fn new(name: &str, version: &str) -> Self {
+        let identity = format!("{}/{}", name, version);
+        let kademlia = format!("/{}/kad/{}", name, version);
+
+        Self {
+            name: name.to_string(),
+            version: version.to_string(),
+            identity,
+            kademlia: StreamProtocol::try_from_owned(kademlia).unwrap(), // guaranteed to unwrap
+        }
+    }
+
+    /// Creates a new instance of the protocol with the given `name` and the current version as per Cargo.toml.
+    /// The verison is represented with `major.minor` version numbers.
+    pub fn new_major_minor(name: &str) -> Self {
+        const VERSION: &str = concat!(
+            env!("CARGO_PKG_VERSION_MAJOR"),
+            ".",
+            env!("CARGO_PKG_VERSION_MINOR")
+        );
+
+        Self::new(name, VERSION)
+    }
+
+    /// Returns the identity protocol, e.g. `dria/0.2`.
+    pub fn identity(&self) -> String {
+        self.identity.clone()
+    }
+
+    /// Returns the kademlia protocol, e.g. `/dria/kad/0.2`.
+    pub fn kademlia(&self) -> StreamProtocol {
+        self.kademlia.clone()
+    }
+
+    /// Returns `true` if the given protocol has a matching prefix with out Kademlia protocol.
+    /// Otherwise, returns `false`.
+    pub fn is_common_kademlia(&self, protocol: &StreamProtocol) -> bool {
+        let kad_prefix = format!("/{}/kad/", self.name);
+        protocol.to_string().starts_with(&kad_prefix)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libp2p::StreamProtocol;
+
+    #[test]
+    fn test_new() {
+        let protocol = DriaP2PProtocol::new("test", "1.0");
+        assert_eq!(protocol.name, "test");
+        assert_eq!(protocol.version, "1.0");
+        assert_eq!(protocol.identity, "test/1.0");
+        assert_eq!(protocol.kademlia.to_string(), "/test/kad/1.0");
+    }
+
+    #[test]
+    fn test_new_major_minor() {
+        let protocol = DriaP2PProtocol::new_major_minor("test");
+        assert_eq!(protocol.name, "test");
+        assert_eq!(
+            protocol.version,
+            concat!(
+                env!("CARGO_PKG_VERSION_MAJOR"),
+                ".",
+                env!("CARGO_PKG_VERSION_MINOR")
+            )
+        );
+        assert_eq!(protocol.identity, format!("test/{}", protocol.version));
+        assert_eq!(
+            protocol.kademlia.to_string(),
+            format!("/test/kad/{}", protocol.version)
+        );
+    }
+
+    #[test]
+    fn test_is_common_kademlia() {
+        let protocol = DriaP2PProtocol::new("test", "1.0");
+        let matching_protocol = StreamProtocol::new("/test/kad/1.0");
+        let non_matching_protocol = StreamProtocol::new("/other/kad/1.0");
+
+        assert!(protocol.is_common_kademlia(&matching_protocol));
+        assert!(!protocol.is_common_kademlia(&non_matching_protocol));
+    }
+}

--- a/p2p/tests/listen_test.rs
+++ b/p2p/tests/listen_test.rs
@@ -4,16 +4,15 @@ use libp2p::Multiaddr;
 use libp2p_identity::Keypair;
 use std::{env, str::FromStr};
 
-const LOG_LEVEL: &str = "none,dkn_p2p=debug";
+const TOPIC: &str = "pong";
+const LOG_LEVEL: &str = "none,listen_test=debug,dkn_p2p=debug";
 
+// FIXME: not working!!!
 #[tokio::test]
 #[ignore = "run manually with logs"]
 async fn test_listen_topic_once() -> Result<()> {
-    // topic to be listened to
-    const TOPIC: &str = "pong";
-
     env::set_var("RUST_LOG", LOG_LEVEL);
-    let _ = env_logger::try_init();
+    let _ = env_logger::builder().is_test(true).try_init();
 
     // setup client
     let keypair = Keypair::generate_secp256k1();
@@ -25,23 +24,53 @@ async fn test_listen_topic_once() -> Result<()> {
         "/ip4/34.201.33.141/tcp/4001/p2p/16Uiu2HAkuXiV2CQkC9eJgU6cMnJ9SMARa85FZ6miTkvn5fuHNufa",
     )?];
     let protocol = DriaP2PProtocol::new_major_minor("dria");
-    let mut client = DriaP2PClient::new(
+
+    // spawn P2P client in another task
+    let (client, mut commander, mut msg_rx) = DriaP2PClient::new(
         keypair,
         addr,
         bootstraps.into_iter(),
         relays.into_iter(),
+        vec![].into_iter(),
         protocol,
-    )?;
+    )
+    .expect("could not create p2p client");
 
     // subscribe to the given topic
-    client.subscribe(TOPIC)?;
+    commander
+        .subscribe(TOPIC)
+        .await
+        .expect("could not subscribe");
+
+    // spawn task
+    let p2p_task = tokio::spawn(async move { client.run().await });
 
     // wait for a single gossipsub message on this topic
-    let message = client.process_events().await;
-    log::info!("Received {} message: {:?}", TOPIC, message);
+    log::info!("Waiting for messages...");
+    let message = msg_rx.recv().await;
+    match message {
+        Some((peer, message_id, _)) => {
+            log::info!("Received {} message {} from {}", TOPIC, message_id, peer);
+        }
+        None => {
+            log::warn!("No message received for topic: {}", TOPIC);
+        }
+    }
 
-    // unsubscribe gracefully
-    client.unsubscribe(TOPIC)?;
+    // unsubscribe to the given topic
+    commander
+        .unsubscribe(TOPIC)
+        .await
+        .expect("could not unsubscribe");
 
+    // close command channel
+    commander.shutdown().await.expect("could not shutdown");
+    // close message channel
+    msg_rx.close();
+
+    log::info!("Waiting for p2p task to finish...");
+    p2p_task.await?;
+
+    log::info!("Done!");
     Ok(())
 }

--- a/p2p/tests/listen_test.rs
+++ b/p2p/tests/listen_test.rs
@@ -1,4 +1,4 @@
-use dkn_p2p::DriaP2PClient;
+use dkn_p2p::{DriaP2PClient, DriaP2PProtocol};
 use eyre::Result;
 use libp2p::Multiaddr;
 use libp2p_identity::Keypair;
@@ -24,7 +24,8 @@ async fn test_listen_topic_once() -> Result<()> {
     let relays = vec![Multiaddr::from_str(
         "/ip4/34.201.33.141/tcp/4001/p2p/16Uiu2HAkuXiV2CQkC9eJgU6cMnJ9SMARa85FZ6miTkvn5fuHNufa",
     )?];
-    let mut client = DriaP2PClient::new(keypair, addr, &bootstraps, &relays, "0.2")?;
+    let protocol = DriaP2PProtocol::new_major_minor("dria");
+    let mut client = DriaP2PClient::new(keypair, addr, &bootstraps, &relays, protocol)?;
 
     // subscribe to the given topic
     client.subscribe(TOPIC)?;

--- a/p2p/tests/listen_test.rs
+++ b/p2p/tests/listen_test.rs
@@ -25,7 +25,13 @@ async fn test_listen_topic_once() -> Result<()> {
         "/ip4/34.201.33.141/tcp/4001/p2p/16Uiu2HAkuXiV2CQkC9eJgU6cMnJ9SMARa85FZ6miTkvn5fuHNufa",
     )?];
     let protocol = DriaP2PProtocol::new_major_minor("dria");
-    let mut client = DriaP2PClient::new(keypair, addr, &bootstraps, &relays, protocol)?;
+    let mut client = DriaP2PClient::new(
+        keypair,
+        addr,
+        bootstraps.into_iter(),
+        relays.into_iter(),
+        protocol,
+    )?;
 
     // subscribe to the given topic
     client.subscribe(TOPIC)?;

--- a/workflows/src/apis/jina.rs
+++ b/workflows/src/apis/jina.rs
@@ -4,8 +4,6 @@ use std::env;
 
 use crate::utils::safe_read_env;
 
-/// Makes a request for `example.com`.
-const JINA_EXAMPLE_ENDPOINT: &str = "https://r.jina.ai/https://example.com";
 const ENV_VAR_NAME: &str = "JINA_API_KEY";
 
 /// Jina-specific configurations.
@@ -46,10 +44,10 @@ impl JinaConfig {
         };
         log::info!("Jina API key found, checking Jina service");
 
-        // make a dummy request models
+        // make a dummy request to "example.com"
         let client = Client::new();
         let request = client
-            .get(JINA_EXAMPLE_ENDPOINT)
+            .get("https://r.jina.ai/https://example.com")
             .header("Authorization", format!("Bearer {}", api_key))
             .build()
             .wrap_err("failed to build request")?;

--- a/workflows/src/bin/tps.rs
+++ b/workflows/src/bin/tps.rs
@@ -1,159 +1,139 @@
-#[cfg(feature = "profiling")]
-mod profile {
-    pub use dkn_workflows::{DriaWorkflowsConfig, OllamaConfig};
-    pub use log::{debug, warn};
-    pub use ollama_workflows::ollama_rs::{
-        generation::{completion::request::GenerationRequest, options::GenerationOptions},
-        Ollama,
-    };
-    pub use ollama_workflows::Model;
-    pub use prettytable::{Cell, Row, Table};
-    pub use sysinfo::{CpuRefreshKind, RefreshKind, System, MINIMUM_CPU_UPDATE_INTERVAL};
-}
+#![cfg(feature = "profiling")]
+
+use dkn_workflows::{DriaWorkflowsConfig, OllamaConfig};
+use ollama_workflows::ollama_rs::{generation::completion::request::GenerationRequest, Ollama};
+use ollama_workflows::Model;
+use prettytable::{Cell, Row, Table};
+use sysinfo::{CpuRefreshKind, RefreshKind, System, MINIMUM_CPU_UPDATE_INTERVAL};
 
 #[tokio::main]
 async fn main() {
-    #[cfg(feature = "profiling")]
-    {
-        use crate::profile::*;
-        // initialize logger
-        env_logger::init();
+    // initialize logger
+    env_logger::init();
 
-        let models = vec![
-            Model::NousTheta,
-            Model::Phi3Medium,
-            Model::Phi3Medium128k,
-            Model::Phi3_5Mini,
-            Model::Phi3_5MiniFp16,
-            Model::Gemma2_9B,
-            Model::Gemma2_9BFp16,
-            Model::Llama3_1_8B,
-            Model::Llama3_1_8Bq8,
-            Model::Llama3_1_8Bf16,
-            Model::Llama3_1_8BTextQ4KM,
-            Model::Llama3_1_8BTextQ8,
-            Model::Llama3_1_70B,
-            Model::Llama3_1_70Bq8,
-            Model::Llama3_1_70BTextQ4KM,
-            Model::Llama3_2_1B,
-            Model::Llama3_2_3B,
-            Model::Llama3_2_1BTextQ4KM,
-            Model::Qwen2_5_7B,
-            Model::Qwen2_5_7Bf16,
-            Model::Qwen2_5_32Bf16,
-            Model::Qwen2_5Coder1_5B,
-            Model::Qwen2_5coder7B,
-            Model::Qwen2_5oder7Bq8,
-            Model::Qwen2_5coder7Bf16,
-            Model::DeepSeekCoder6_7B,
-            Model::Mixtral8_7b,
-            Model::GPT4Turbo,
-            Model::GPT4o,
-            Model::GPT4oMini,
-            Model::O1Preview,
-            Model::O1Mini,
-            Model::Gemini15ProExp0827,
-            Model::Gemini15Pro,
-            Model::Gemini15Flash,
-            Model::Gemini10Pro,
-            Model::Gemma2_2bIt,
-            Model::Gemma2_27bIt,
-        ];
+    let models = vec![
+        Model::NousTheta,
+        Model::Phi3Medium,
+        Model::Phi3Medium128k,
+        Model::Phi3_5Mini,
+        Model::Phi3_5MiniFp16,
+        Model::Gemma2_9B,
+        Model::Gemma2_9BFp16,
+        Model::Llama3_1_8B,
+        Model::Llama3_1_8Bq8,
+        Model::Llama3_1_8Bf16,
+        Model::Llama3_1_8BTextQ4KM,
+        Model::Llama3_1_8BTextQ8,
+        Model::Llama3_1_70B,
+        Model::Llama3_1_70Bq8,
+        Model::Llama3_1_70BTextQ4KM,
+        Model::Llama3_2_1B,
+        Model::Llama3_2_3B,
+        Model::Llama3_2_1BTextQ4KM,
+        Model::Qwen2_5_7B,
+        Model::Qwen2_5_7Bf16,
+        Model::Qwen2_5_32Bf16,
+        Model::Qwen2_5Coder1_5B,
+        Model::Qwen2_5coder7B,
+        Model::Qwen2_5oder7Bq8,
+        Model::Qwen2_5coder7Bf16,
+        Model::DeepSeekCoder6_7B,
+        Model::Mixtral8_7b,
+        Model::GPT4Turbo,
+        Model::GPT4o,
+        Model::GPT4oMini,
+        Model::O1Preview,
+        Model::O1Mini,
+        Model::Gemini15ProExp0827,
+        Model::Gemini15Pro,
+        Model::Gemini15Flash,
+        Model::Gemini10Pro,
+        Model::Gemma2_2bIt,
+        Model::Gemma2_27bIt,
+    ];
 
-        let cfg = DriaWorkflowsConfig::new(models);
-        let config = OllamaConfig::default();
-        let ollama = Ollama::new(config.host, config.port);
-        debug!("Starting...");
-        // ensure that all lists of CPUs and processes are filled
-        let mut system = System::new_all();
-        // update all information of the system
-        system.refresh_all();
+    let cfg = DriaWorkflowsConfig::new(models);
+    let config = OllamaConfig::default();
+    let ollama = Ollama::new(config.host, config.port);
+    log::debug!("Starting...");
+    // ensure that all lists of CPUs and processes are filled
+    let mut system = System::new_all();
+    // update all information of the system
+    system.refresh_all();
 
-        debug!("Getting system information...");
-        let brand = system.cpus()[0].brand().to_string();
-        let os_name = System::name().unwrap_or_else(|| "Unknown".to_string());
-        let os_version = System::long_os_version().unwrap_or_else(|| "Unknown".to_string());
-        let cpu_usage = system.global_cpu_usage();
-        let total_memory = system.total_memory();
-        let used_memory = system.used_memory();
-        let mut tps = 0 as f64;
-        let mut table = Table::new();
+    log::debug!("Getting system information...");
+    let brand = system.cpus()[0].brand().to_string();
+    let os_name = System::name().unwrap_or_else(|| "Unknown".to_string());
+    let os_version = System::long_os_version().unwrap_or_else(|| "Unknown".to_string());
+    let cpu_usage = system.global_cpu_usage();
+    let total_memory = system.total_memory();
+    let used_memory = system.used_memory();
+    let mut tps: f64;
+    let mut table = Table::new();
 
-        // Add a row with the headers
-        table.add_row(Row::new(vec![
-            Cell::new("Model"),
-            Cell::new("TPS"),
-            Cell::new("OS"),
-            Cell::new("Version"),
-            Cell::new("CPU Usage (%)"),
-            Cell::new("Total Memory (KB)"),
-            Cell::new("Used Memory (KB)"),
-        ]));
+    // Add a row with the headers
+    table.add_row(Row::new(vec![
+        Cell::new("Model"),
+        Cell::new("TPS"),
+        Cell::new("OS"),
+        Cell::new("Version"),
+        Cell::new("CPU Usage (%)"),
+        Cell::new("Total Memory (KB)"),
+        Cell::new("Used Memory (KB)"),
+    ]));
 
-        for (_, model) in cfg.models {
-            debug!("Pulling model: {}", model);
+    for (_, model) in cfg.models {
+        log::debug!("Pulling model: {}", model);
 
-            // pull model
-            match ollama.pull_model(model.to_string(), false).await {
-                Ok(status) => debug!("Status: {}", status.message),
-                Err(err) => {
-                    log::error!("Failed to pull model {}: {:?}", model, err);
-                }
+        // pull model
+        match ollama.pull_model(model.to_string(), false).await {
+            Ok(status) => log::debug!("Status: {}", status.message),
+            Err(err) => {
+                log::error!("Failed to pull model {}: {:?}", model, err);
             }
-
-            log::debug!("Creating request...");
-            // create dummy request
-            let mut generation_request =
-                GenerationRequest::new(model.to_string(), "compute 6780 * 1200".to_string());
-
-            if let Ok(num_thread) = std::env::var("OLLAMA_NUM_THREAD") {
-                generation_request = generation_request.options(
-                    GenerationOptions::default().num_thread(
-                        num_thread
-                            .parse()
-                            .expect("num threads should be a positive integer"),
-                    ),
-                );
-            }
-
-            // generate response
-            match ollama.generate(generation_request).await {
-                Ok(response) => {
-                    debug!("Got response for model {}", model);
-
-                    // compute TPS
-                    tps = (response.eval_count.unwrap_or_default() as f64)
-                        / (response.eval_duration.unwrap_or(1) as f64)
-                        * 1_000_000_000f64;
-
-                    // add row to table
-                    table.add_row(Row::new(vec![
-                        Cell::new(&model.to_string()),
-                        Cell::new(&tps.to_string()),
-                        Cell::new(&format!("{} {}", brand, os_name)),
-                        Cell::new(&os_version),
-                        Cell::new(&cpu_usage.to_string()),
-                        Cell::new(&total_memory.to_string()),
-                        Cell::new(&used_memory.to_string()),
-                    ]));
-                }
-                Err(e) => {
-                    warn!("Ignoring model {}: Workflow failed with error {}", model, e);
-                }
-            }
-            table.printstd();
-            // print system info
-            // refresh CPU usage (https://docs.rs/sysinfo/latest/sysinfo/struct.Cpu.html#method.cpu_usage)
-            system = System::new_with_specifics(
-                RefreshKind::new().with_cpu(CpuRefreshKind::everything()),
-            );
-            // wait a bit because CPU usage is based on diff
-            std::thread::sleep(MINIMUM_CPU_UPDATE_INTERVAL);
-            // refresh CPUs again to get actual value
-            system.refresh_cpu_usage();
         }
-        // print system info
+
+        log::debug!("Creating request...");
+        // create dummy request as a warm-up
+        let generation_request =
+            GenerationRequest::new(model.to_string(), "compute 6780 * 1200".to_string());
+
+        // generate response
+        match ollama.generate(generation_request).await {
+            Ok(response) => {
+                log::debug!("Got response for model {}", model);
+
+                // compute TPS
+                tps = (response.eval_count.unwrap_or_default() as f64)
+                    / (response.eval_duration.unwrap_or(1) as f64)
+                    * 1_000_000_000f64;
+
+                // add row to table
+                table.add_row(Row::new(vec![
+                    Cell::new(&model.to_string()),
+                    Cell::new(&tps.to_string()),
+                    Cell::new(&format!("{} {}", brand, os_name)),
+                    Cell::new(&os_version),
+                    Cell::new(&cpu_usage.to_string()),
+                    Cell::new(&total_memory.to_string()),
+                    Cell::new(&used_memory.to_string()),
+                ]));
+            }
+            Err(e) => {
+                log::warn!("Ignoring model {}: Workflow failed with error {}", model, e);
+            }
+        }
         table.printstd();
-        debug!("Finished");
+        // print system info
+        // refresh CPU usage (https://docs.rs/sysinfo/latest/sysinfo/struct.Cpu.html#method.cpu_usage)
+        system =
+            System::new_with_specifics(RefreshKind::new().with_cpu(CpuRefreshKind::everything()));
+        // wait a bit because CPU usage is based on diff
+        std::thread::sleep(MINIMUM_CPU_UPDATE_INTERVAL);
+        // refresh CPUs again to get actual value
+        system.refresh_cpu_usage();
     }
+    // print system info
+    table.printstd();
+    log::debug!("Finished");
 }

--- a/workflows/src/providers/gemini.rs
+++ b/workflows/src/providers/gemini.rs
@@ -185,7 +185,7 @@ mod tests {
         let _ = dotenvy::dotenv(); // read api key
         assert!(env::var(ENV_VAR_NAME).is_ok(), "should have api key");
         env::set_var("RUST_LOG", "none,dkn_workflows=debug");
-        let _ = env_logger::try_init();
+        let _ = env_logger::builder().is_test(true).try_init();
 
         let models = vec![
             Model::Gemini10Pro,

--- a/workflows/src/providers/openai.rs
+++ b/workflows/src/providers/openai.rs
@@ -172,7 +172,7 @@ mod tests {
         let _ = dotenvy::dotenv(); // read api key
         assert!(env::var(ENV_VAR_NAME).is_ok(), "should have api key");
         env::set_var("RUST_LOG", "none,dkn_workflows=debug");
-        let _ = env_logger::try_init();
+        let _ = env_logger::builder().is_test(true).try_init();
 
         let models = vec![Model::GPT4Turbo, Model::GPT4o, Model::GPT4oMini];
         let config = OpenAIConfig::new();

--- a/workflows/src/providers/openrouter.rs
+++ b/workflows/src/providers/openrouter.rs
@@ -120,7 +120,7 @@ mod tests {
         let _ = dotenvy::dotenv(); // read api key
         assert!(env::var(ENV_VAR_NAME).is_ok(), "should have api key");
         env::set_var("RUST_LOG", "none,dkn_workflows=debug");
-        let _ = env_logger::try_init();
+        let _ = env_logger::builder().is_test(true).try_init();
 
         let models = vec![Model::GPT4Turbo, Model::GPT4o, Model::GPT4oMini];
         let config = OpenRouterConfig::new();

--- a/workflows/tests/models_test.rs
+++ b/workflows/tests/models_test.rs
@@ -8,7 +8,7 @@ const LOG_LEVEL: &str = "none,dkn_workflows=debug";
 #[ignore = "requires Ollama"]
 async fn test_ollama_check() -> Result<()> {
     env::set_var("RUST_LOG", LOG_LEVEL);
-    let _ = env_logger::try_init();
+    let _ = env_logger::builder().is_test(true).try_init();
 
     let models = vec![Model::Phi3_5Mini];
     let mut model_config = DriaWorkflowsConfig::new(models);
@@ -27,7 +27,7 @@ async fn test_ollama_check() -> Result<()> {
 async fn test_openai_check() -> Result<()> {
     let _ = dotenvy::dotenv(); // read api key
     env::set_var("RUST_LOG", LOG_LEVEL);
-    let _ = env_logger::try_init();
+    let _ = env_logger::builder().is_test(true).try_init();
 
     let models = vec![Model::GPT4Turbo];
     let mut model_config = DriaWorkflowsConfig::new(models);


### PR DESCRIPTION
- [x] Set max established outgoing connections to 300 (from 450).
- [x] Refresh time is 25 secs now.
- [x] Added multi-network capability with `DriaNetworkType` enum.
- [x] Added `DriaP2PProtocol` struct that helps manage protocol names.
- [x] Added `blacklist` and `disconnect` when a peer with wrong protocols are identified, this is expected to help with reporting a more correct peer count
- [x] Add multi-threading (https://github.com/firstbatchxyz/dkn-compute-node/pull/150)