### PR TITLE
feat: publish-in-task

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ DKN_ADMIN_PUBLIC_KEY=0208ef5e65a9c656a6f92fb2c770d5d5e2ecffe02a6aade19207f75110b
 # example: phi3:3.8b,gpt-4o-mini
 DKN_MODELS=
 
+
 ## DRIA (optional) ##
 # P2P address, you don't need to change this unless this port is already in use.
 DKN_P2P_LISTEN_ADDR=/ip4/0.0.0.0/tcp/4001
@@ -16,6 +17,8 @@ DKN_P2P_LISTEN_ADDR=/ip4/0.0.0.0/tcp/4001
 DKN_RELAY_NODES=
 # Comma-separated static bootstrap nodes
 DKN_BOOTSTRAP_NODES=
+# Batch size for workflows, you do not need to edit this.
+DKN_BATCH_SIZE=
 
 ## DRIA (profiling only, do not uncomment) ##
 # Set to a number of seconds to wait before exiting, only use in profiling build!

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-compute"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-monitor"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "async-trait",
  "dkn-compute",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-p2p"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "dkn-utils",
  "env_logger 0.11.5",
@@ -1041,11 +1041,11 @@ dependencies = [
 
 [[package]]
 name = "dkn-utils"
-version = "0.2.26"
+version = "0.2.27"
 
 [[package]]
 name = "dkn-workflows"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "dkn-utils",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ default-members = ["compute"]
 
 [workspace.package]
 edition = "2021"
-version = "0.2.26"
+version = "0.2.27"
 license = "Apache-2.0"
 readme = "README.md"
 

--- a/compute/src/config.rs
+++ b/compute/src/config.rs
@@ -9,6 +9,9 @@ use libsecp256k1::{PublicKey, SecretKey};
 
 use std::{env, str::FromStr};
 
+// TODO: make this configurable later
+const DEFAULT_WORKFLOW_BATCH_SIZE: usize = 5;
+
 #[derive(Debug, Clone)]
 pub struct DriaComputeNodeConfig {
     /// Wallet secret/private key.
@@ -25,6 +28,11 @@ pub struct DriaComputeNodeConfig {
     pub workflows: DriaWorkflowsConfig,
     /// Network type of the node.
     pub network_type: DriaNetworkType,
+    /// Batch size for batchable workflows.
+    ///
+    /// A higher value will help execute more tasks concurrently,
+    /// at the risk of hitting rate-limits.
+    pub batch_size: usize,
 }
 
 /// The default P2P network listen address.
@@ -103,6 +111,11 @@ impl DriaComputeNodeConfig {
             .map(|s| DriaNetworkType::from(s.as_str()))
             .unwrap_or_default();
 
+        // parse batch size
+        let batch_size = env::var("DKN_BATCH_SIZE")
+            .map(|s| s.parse::<usize>().unwrap_or(DEFAULT_WORKFLOW_BATCH_SIZE))
+            .unwrap_or(DEFAULT_WORKFLOW_BATCH_SIZE);
+
         Self {
             admin_public_key,
             secret_key,
@@ -111,6 +124,7 @@ impl DriaComputeNodeConfig {
             workflows,
             p2p_listen_addr,
             network_type,
+            batch_size,
         }
     }
 

--- a/compute/src/handlers/workflow.rs
+++ b/compute/src/handlers/workflow.rs
@@ -129,11 +129,7 @@ impl WorkflowHandler {
 
                 // convert payload to message
                 let payload_str = serde_json::json!(payload).to_string();
-                log::info!(
-                    "Publishing result for task {}\n{}",
-                    task.task_id,
-                    payload_str
-                );
+                log::info!("Publishing result for task {}", task.task_id);
                 DriaMessage::new(payload_str, Self::RESPONSE_TOPIC)
             }
             Err(err) => {

--- a/compute/src/handlers/workflow.rs
+++ b/compute/src/handlers/workflow.rs
@@ -129,7 +129,7 @@ impl WorkflowHandler {
 
                 // convert payload to message
                 let payload_str = serde_json::json!(payload).to_string();
-                log::debug!(
+                log::info!(
                     "Publishing result for task {}\n{}",
                     task.task_id,
                     payload_str
@@ -161,7 +161,7 @@ impl WorkflowHandler {
 
         // try publishing the result
         if let Err(publish_err) = node.publish(message).await {
-            let err_msg = format!("could not publish result: {:?}", publish_err);
+            let err_msg = format!("Could not publish task result: {:?}", publish_err);
             log::error!("{}", err_msg);
 
             let payload = serde_json::json!({

--- a/compute/src/node.rs
+++ b/compute/src/node.rs
@@ -81,9 +81,7 @@ impl DriaComputeNode {
         let (p2p_client, p2p_commander, message_rx) = DriaP2PClient::new(
             keypair,
             config.p2p_listen_addr.clone(),
-            available_nodes.bootstrap_nodes.clone().into_iter(),
-            available_nodes.relay_nodes.clone().into_iter(),
-            available_nodes.rpc_nodes.clone().into_iter(),
+            &available_nodes,
             protocol,
         )?;
 

--- a/monitor/src/main.rs
+++ b/monitor/src/main.rs
@@ -33,9 +33,7 @@ async fn main() -> eyre::Result<()> {
     let (client, commander, msg_rx) = DriaP2PClient::new(
         keypair,
         listen_addr,
-        nodes.bootstrap_nodes.into_iter(),
-        nodes.relay_nodes.into_iter(),
-        nodes.rpc_nodes.into_iter(),
+        &nodes,
         DriaP2PProtocol::new_major_minor(network.protocol_name()),
     )?;
 

--- a/p2p/src/nodes.rs
+++ b/p2p/src/nodes.rs
@@ -29,6 +29,26 @@ impl DriaNodes {
         }
     }
 
+    pub fn with_relay_nodes(mut self, addresses: impl IntoIterator<Item = Multiaddr>) -> Self {
+        self.relay_nodes.extend(addresses);
+        self
+    }
+
+    pub fn with_bootstrap_nodes(mut self, addresses: impl IntoIterator<Item = Multiaddr>) -> Self {
+        self.bootstrap_nodes.extend(addresses);
+        self
+    }
+
+    pub fn with_rpc_nodes(mut self, addresses: impl IntoIterator<Item = Multiaddr>) -> Self {
+        self.rpc_nodes.extend(addresses);
+        self
+    }
+
+    pub fn with_rpc_peer_ids(mut self, addresses: impl IntoIterator<Item = PeerId>) -> Self {
+        self.rpc_peerids.extend(addresses);
+        self
+    }
+
     /// Parses static bootstrap & relay nodes from environment variables.
     ///
     /// The environment variables are:

--- a/p2p/tests/listen_test.rs
+++ b/p2p/tests/listen_test.rs
@@ -1,4 +1,4 @@
-use dkn_p2p::{DriaP2PClient, DriaP2PProtocol};
+use dkn_p2p::{DriaNodes, DriaP2PClient, DriaP2PProtocol};
 use eyre::Result;
 use libp2p_identity::Keypair;
 
@@ -12,13 +12,18 @@ async fn test_listen_topic_once() -> Result<()> {
         .is_test(true)
         .try_init();
 
+    let listen_addr = "/ip4/0.0.0.0/tcp/4001".parse()?;
+
+    // prepare nodes
+    let nodes = DriaNodes::new(dkn_p2p::DriaNetworkType::Community)
+    .with_bootstrap_nodes(["/ip4/44.206.245.139/tcp/4001/p2p/16Uiu2HAm4q3LZU2T9kgjKK4ysy6KZYKLq8KiXQyae4RHdF7uqSt4".parse()?])
+    .with_relay_nodes(["/ip4/34.201.33.141/tcp/4001/p2p/16Uiu2HAkuXiV2CQkC9eJgU6cMnJ9SMARa85FZ6miTkvn5fuHNufa".parse()?]);
+
     // spawn P2P client in another task
     let (client, mut commander, mut msg_rx) = DriaP2PClient::new(
         Keypair::generate_secp256k1(),
-        "/ip4/0.0.0.0/tcp/4001".parse()?,
-        vec!["/ip4/44.206.245.139/tcp/4001/p2p/16Uiu2HAm4q3LZU2T9kgjKK4ysy6KZYKLq8KiXQyae4RHdF7uqSt4".parse()?].into_iter(),
-        vec!["/ip4/34.201.33.141/tcp/4001/p2p/16Uiu2HAkuXiV2CQkC9eJgU6cMnJ9SMARa85FZ6miTkvn5fuHNufa".parse()?].into_iter(),
-        vec![].into_iter(),
+        listen_addr,
+        &nodes,
         DriaP2PProtocol::default(),
     )
     .expect("could not create p2p client");


### PR DESCRIPTION
- [x] Added configurable batch size via `DKN_BATCH_SIZE` var. If this is larger than the max size (8 right now) it will give an error.
- [x] Default batch size moved from 8 to 5.
- [x] Added `publish` to the batched task. This solves the problem of "batch being as fast as the slowest task in it", because publish had to wait for all tasks in `tokio::join` to finish. Now, each task immediately publishes their result when they are finished.
- [x] Small log level changes
- [x] Bump patch version (26 -> 27)