### PR TITLE
feat: better error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-compute"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "base64",
  "chrono",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-executor"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "dotenvy",
  "enum-iterator",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-p2p"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "dkn-utils",
  "env_logger",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "dkn-utils"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,7 @@ dependencies = [
 name = "dkn-executor"
 version = "0.6.0"
 dependencies = [
+ "dkn-utils",
  "dotenvy",
  "enum-iterator",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["compute"]
 
 [workspace.package]
 edition = "2021"
-version = "0.5.7"
+version = "0.6.0"
 license = "Apache-2.0"
 readme = "README.md"
 

--- a/compute/src/node/diagnostic.rs
+++ b/compute/src/node/diagnostic.rs
@@ -85,9 +85,10 @@ impl DriaComputeNode {
 
     /// Dials the existing RPC node if we are not connected to it.
     ///
-    /// If there is an error while doing that,
-    /// it will try to get a new RPC node and dial it.
-    pub(crate) async fn handle_rpc_liveness_check(&mut self) {
+    /// If there is an error while doing that, it will try to get a new RPC node and dial it.
+    ///
+    /// Returns `true` if the RPC is connected, `false` otherwise.
+    pub(crate) async fn handle_rpc_liveness_check(&mut self) -> bool {
         log::debug!("Checking RPC connections for diagnostics.");
 
         // check if we are connected
@@ -124,6 +125,9 @@ impl DriaComputeNode {
         } else {
             log::debug!("Connection with {} is intact.", self.dria_rpc.peer_id);
         }
+
+        // return the connection status
+        is_connected
     }
 
     /// Updates the points for the given address.

--- a/compute/src/node/mod.rs
+++ b/compute/src/node/mod.rs
@@ -1,7 +1,8 @@
+use dkn_executor::Model;
 use dkn_p2p::{
     libp2p::PeerId, DriaP2PClient, DriaP2PCommander, DriaP2PProtocol, DriaReqResMessage,
 };
-use dkn_utils::crypto::secret_to_keypair;
+use dkn_utils::{crypto::secret_to_keypair, payloads::SpecModelPerformance};
 use eyre::Result;
 use std::collections::{HashMap, HashSet};
 use tokio::sync::mpsc;
@@ -68,6 +69,7 @@ impl DriaComputeNode {
     /// Returns the node instance and p2p client together. P2p MUST be run in a separate task before this node is used at all.
     pub async fn new(
         mut config: DriaComputeNodeConfig,
+        model_perf: HashMap<Model, SpecModelPerformance>,
     ) -> Result<(
         DriaComputeNode,
         DriaP2PClient,
@@ -124,7 +126,7 @@ impl DriaComputeNode {
         let model_names = config.executors.get_model_names();
         let points_client = DriaPointsClient::new(&config.address, &config.network)?;
 
-        let spec_collector = SpecCollector::new(model_names.clone(), config.version);
+        let spec_collector = SpecCollector::new(model_names.clone(), model_perf, config.version);
         Ok((
             DriaComputeNode {
                 config,

--- a/compute/src/reqres/task.rs
+++ b/compute/src/reqres/task.rs
@@ -1,7 +1,9 @@
 use colored::Colorize;
-use dkn_executor::TaskBody;
+use dkn_executor::{CompletionError, ModelProvider, PromptError, TaskBody};
 use dkn_p2p::libp2p::request_response::ResponseChannel;
-use dkn_utils::payloads::{TaskRequestPayload, TaskResponsePayload, TaskStats, TASK_RESULT_TOPIC};
+use dkn_utils::payloads::{
+    TaskError, TaskRequestPayload, TaskResponsePayload, TaskStats, TASK_RESULT_TOPIC,
+};
 use dkn_utils::DriaMessage;
 use eyre::{Context, Result};
 
@@ -25,27 +27,23 @@ impl TaskResponder {
         let task = compute_message
             .parse_payload::<TaskRequestPayload<serde_json::Value>>()
             .wrap_err("could not parse task request payload")?;
-        let task_body = match serde_json::from_value::<TaskBody>(task.input)
-            .wrap_err("could not parse task body")
-        {
+        let task_body = match serde_json::from_value::<TaskBody>(task.input) {
             Ok(task_body) => task_body,
             Err(err) => {
-                let err_string = format!("{:#}", err);
                 log::error!(
-                    "Task {}/{} failed due to parsing error: {}",
+                    "Task {}/{} failed due to parsing error: {err}",
                     task.file_id,
                     task.row_id,
-                    err_string
                 );
 
                 // prepare error payload
                 let error_payload = TaskResponsePayload {
                     result: None,
-                    error: Some(err_string),
+                    error: Some(TaskError::ParseError(err.to_string())),
                     row_id: task.row_id,
                     file_id: task.file_id,
                     task_id: task.task_id,
-                    model: Default::default(),
+                    model: "<n/a>".to_string(), // no model available due to parsing error
                     stats: TaskStats::new(),
                 };
 
@@ -56,7 +54,8 @@ impl TaskResponder {
                 let response = node.new_message(error_payload_str, TASK_RESULT_TOPIC);
                 node.p2p.respond(response.into(), channel).await?;
 
-                return Err(err);
+                // return with error
+                eyre::bail!("could not parse task body: {err}")
             }
         };
 
@@ -75,7 +74,7 @@ impl TaskResponder {
         let task_metadata = TaskWorkerMetadata {
             task_id: task.task_id,
             file_id: task.file_id,
-            model_name: task_body.model.to_string(),
+            model: task_body.model,
             channel,
         };
         let task_input = TaskWorkerInput {
@@ -112,7 +111,7 @@ impl TaskResponder {
                     file_id: task_metadata.file_id,
                     task_id: task_metadata.task_id,
                     row_id: task_output.row_id,
-                    model: task_metadata.model_name,
+                    model: task_metadata.model.to_string(),
                     stats: task_output
                         .stats
                         .record_published_at()
@@ -125,22 +124,21 @@ impl TaskResponder {
             }
             Err(err) => {
                 // use pretty display string for error logging with causes
-                let err_string = format!("{:#}", err);
                 log::error!(
-                    "Task {}/{} failed: {}",
+                    "Task {}/{} failed: {:#}",
                     task_metadata.file_id,
                     task_output.row_id,
-                    err_string
+                    err
                 );
 
                 // prepare error payload
                 let error_payload = TaskResponsePayload {
                     result: None,
-                    error: Some(err_string),
+                    error: Some(map_prompt_error(task_metadata.model.provider(), err)),
                     row_id: task_output.row_id,
                     file_id: task_metadata.file_id,
                     task_id: task_metadata.task_id,
-                    model: task_metadata.model_name,
+                    model: task_metadata.model.to_string(),
                     stats: task_output
                         .stats
                         .record_published_at()
@@ -159,5 +157,106 @@ impl TaskResponder {
             .await?;
 
         Ok(())
+    }
+}
+
+/// Maps a [`PromptError`] to a [`DriaExecutorError`] with respect to the given provider.
+fn map_prompt_error(provider: ModelProvider, err: PromptError) -> TaskError {
+    if let PromptError::CompletionError(CompletionError::ProviderError(err_inner)) = &err {
+        /// A wrapper for `{ error: T }` to match the provider error format.
+        #[derive(Clone, serde::Deserialize)]
+        struct ErrorObject<T> {
+            error: T,
+        }
+
+        match provider {
+            ModelProvider::Gemini => {
+                /// Gemini API [error object](https://github.com/googleapis/go-genai/blob/main/api_client.go#L273).
+                #[derive(Clone, serde::Deserialize)]
+                pub struct GeminiError {
+                    code: u32,
+                    message: String,
+                    status: String,
+                }
+
+                serde_json::from_str::<ErrorObject<GeminiError>>(err_inner).map(
+                    |ErrorObject {
+                         error: gemini_error,
+                     }| TaskError::ProviderError {
+                        code: format!("{} ({})", gemini_error.code, gemini_error.status),
+                        message: gemini_error.message,
+                        provider: provider.to_string(),
+                    },
+                )
+            }
+            ModelProvider::OpenAI => {
+                /// OpenAI API [error object](https://github.com/openai/openai-go/blob/main/internal/apierror/apierror.go#L17).
+                #[derive(Clone, serde::Deserialize)]
+                pub struct OpenAIError {
+                    code: String,
+                    message: String,
+                }
+
+                serde_json::from_str::<ErrorObject<OpenAIError>>(err_inner).map(
+                    |ErrorObject {
+                         error: openai_error,
+                     }| TaskError::ProviderError {
+                        code: openai_error.code,
+                        message: openai_error.message,
+                        provider: provider.to_string(),
+                    },
+                )
+            }
+            ModelProvider::OpenRouter => {
+                /// OpenRouter API [error object](https://openrouter.ai/docs/api-reference/errors).
+                #[derive(Clone, serde::Deserialize)]
+                pub struct OpenRouterError {
+                    code: u32,
+                    message: String,
+                }
+
+                serde_json::from_str::<ErrorObject<OpenRouterError>>(err_inner).map(
+                    |ErrorObject {
+                         error: openrouter_error,
+                     }| {
+                        TaskError::ProviderError {
+                            code: openrouter_error.code.to_string(),
+                            message: openrouter_error.message,
+                            provider: provider.to_string(),
+                        }
+                    },
+                )
+            }
+            ModelProvider::Ollama => serde_json::from_str::<ErrorObject<String>>(err_inner).map(
+                // Ollama just returns a string error message
+                |ErrorObject {
+                     error: ollama_error,
+                 }| {
+                    // based on the error message, we can come up with out own "dummy" codes
+                    let code = if ollama_error.contains("server busy, please try again.") {
+                        "server_busy"
+                    } else if ollama_error.contains("model requires more system memory") {
+                        "model_requires_more_memory"
+                    } else if ollama_error.contains("cudaMalloc failed: out of memory") {
+                        "cuda_malloc_failed"
+                    } else if ollama_error.contains("CUDA error: out of memory") {
+                        "cuda_oom"
+                    } else {
+                        "unknown"
+                    };
+
+                    TaskError::ProviderError {
+                        code: code.to_string(),
+                        message: ollama_error,
+                        provider: provider.to_string(),
+                    }
+                },
+            ),
+        }
+        // if we couldn't parse it, just return a generic prompt error
+        .unwrap_or(TaskError::Other(err.to_string()))
+    } else {
+        // not a provider error, fallback to generic prompt error
+        TaskError::Other(err.to_string())
     }
 }

--- a/compute/src/workers/task.rs
+++ b/compute/src/workers/task.rs
@@ -1,5 +1,5 @@
 use colored::Colorize;
-use dkn_executor::{DriaExecutor, TaskBody};
+use dkn_executor::{DriaExecutor, Model, TaskBody};
 use dkn_p2p::libp2p::request_response::ResponseChannel;
 use dkn_utils::payloads::TaskStats;
 use tokio::sync::mpsc;
@@ -9,7 +9,7 @@ use uuid::Uuid;
 ///
 /// This is put into a map before execution, and then removed after the task is done.
 pub struct TaskWorkerMetadata {
-    pub model_name: String,
+    pub model: Model,
     pub task_id: String,
     pub file_id: Uuid,
     /// If for any reason this object is dropped before `channel` is responded to,

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -29,6 +29,7 @@ thiserror.workspace = true
 enum-iterator = "2.1.0"
 rig-core = "0.11.1"
 ollama-rs = { version = "0.3.0", features = ["tokio", "rustls", "stream"] }
+dkn-utils = { path = "../utils" }
 
 [dev-dependencies]
 # only used for tests

--- a/executor/src/executors/mod.rs
+++ b/executor/src/executors/mod.rs
@@ -1,4 +1,5 @@
 use crate::{Model, ModelProvider, TaskBody};
+use dkn_utils::payloads::SpecModelPerformance;
 use rig::completion::PromptError;
 use std::collections::{HashMap, HashSet};
 
@@ -50,7 +51,7 @@ impl DriaExecutor {
     pub async fn check(
         &self,
         models: &mut HashSet<Model>,
-    ) -> eyre::Result<HashMap<Model, ModelPerformanceMetric>> {
+    ) -> eyre::Result<HashMap<Model, SpecModelPerformance>> {
         match self {
             DriaExecutor::Ollama(provider) => provider.check(models).await,
             DriaExecutor::OpenAI(provider) => provider.check(models).await,
@@ -58,10 +59,4 @@ impl DriaExecutor {
             DriaExecutor::OpenRouter(provider) => provider.check(models).await,
         }
     }
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub enum ModelPerformanceMetric {
-    Latency(f64), // in seconds
-    TPS(f64),     // (eval) tokens per second
 }

--- a/executor/src/executors/mod.rs
+++ b/executor/src/executors/mod.rs
@@ -38,13 +38,9 @@ impl DriaExecutor {
     pub async fn execute(&self, task: crate::TaskBody) -> Result<String, PromptError> {
         match self {
             DriaExecutor::Ollama(provider) => provider.execute(task).await,
-            // .map_err(|e| map_prompt_error(&ModelProvider::Ollama, e)),
             DriaExecutor::OpenAI(provider) => provider.execute(task).await,
-            // .map_err(|e| map_prompt_error(&ModelProvider::OpenAI, e)),
             DriaExecutor::Gemini(provider) => provider.execute(task).await,
-            // .map_err(|e| map_prompt_error(&ModelProvider::Gemini, e)),
             DriaExecutor::OpenRouter(provider) => provider.execute(task).await,
-            // .map_err(|e| map_prompt_error(&ModelProvider::OpenRouter, e)),
         }
     }
 

--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -47,5 +47,7 @@ fn create_identify_behaviour(
 ) -> identify::Behaviour {
     use identify::{Behaviour, Config};
 
-    Behaviour::new(Config::new(protocol_version, local_public_key))
+    Behaviour::new(
+        Config::new(protocol_version, local_public_key).with_push_listen_addr_updates(true),
+    )
 }

--- a/utils/src/payloads/mod.rs
+++ b/utils/src/payloads/mod.rs
@@ -8,4 +8,4 @@ pub use heartbeat::{HeartbeatRequest, HeartbeatResponse};
 
 mod specs;
 pub use specs::SPECS_TOPIC;
-pub use specs::{Specs, SpecsRequest, SpecsResponse};
+pub use specs::{SpecModelPerformance, Specs, SpecsRequest, SpecsResponse};

--- a/utils/src/payloads/mod.rs
+++ b/utils/src/payloads/mod.rs
@@ -1,5 +1,5 @@
 mod tasks;
-pub use tasks::{TaskRequestPayload, TaskResponsePayload, TaskStats};
+pub use tasks::{TaskError, TaskRequestPayload, TaskResponsePayload, TaskStats};
 pub use tasks::{TASK_REQUEST_TOPIC, TASK_RESULT_TOPIC};
 
 mod heartbeat;

--- a/utils/src/payloads/tasks.rs
+++ b/utils/src/payloads/tasks.rs
@@ -33,11 +33,11 @@ pub struct TaskResponsePayload {
     /// If this is `None`, the task failed, and you should check the `error` field.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<String>,
-    /// An error message, if any.
+    /// An error, if any.
     ///
     /// If this is `Some`, you can ignore the `result` field.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
+    pub error: Option<TaskError>,
 }
 
 /// A generic task request, given by Dria.
@@ -55,6 +55,35 @@ pub struct TaskRequestPayload<T> {
     pub task_id: String,
     /// The input to the compute function.
     pub input: T,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TaskError {
+    /// A parse error occurred while parsing the task request or response.
+    ParseError(String),
+    /// An error returned from the model provider.
+    ProviderError {
+        /// Not necessarily an HTTP status code, but a code that the provider uses to identify the error.
+        ///
+        /// For example, OpenAI uses a string code like "invalid_request_error".
+        code: String,
+        /// The error message returned by the provider.
+        ///
+        /// May contain additional information about the error.
+        message: String,
+        /// The source of the error.
+        ///
+        /// Can be a provider name, or RPC etc.
+        provider: String,
+    },
+    /// The task request had failed for some network reason.
+    OutboundRequestError {
+        code: String,
+        /// The error message returned by the network.
+        message: String,
+    },
+    /// An error that returned by executor.
+    Other(String),
 }
 
 /// Task stats for diagnostics.

--- a/utils/src/payloads/tasks.rs
+++ b/utils/src/payloads/tasks.rs
@@ -78,9 +78,8 @@ pub enum TaskError {
         /// Can be a provider name, or RPC etc.
         provider: String,
     },
-    /// A network-related error from the client.
-    #[error("HTTP error: {0}")]
     /// This is a generic HTTP error, not necessarily related to the provider.
+    #[error("HTTP error: {0}")]
     HttpError(String),
     /// Any other executor error that is not a provider error.
     #[error("Executor error: {0}")]

--- a/utils/src/payloads/tasks.rs
+++ b/utils/src/payloads/tasks.rs
@@ -57,11 +57,13 @@ pub struct TaskRequestPayload<T> {
     pub input: T,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error)]
 pub enum TaskError {
     /// A parse error occurred while parsing the task request or response.
+    #[error("Parse error: {0}")]
     ParseError(String),
     /// An error returned from the model provider.
+    #[error("Provider error: {code} - {message} (source: {provider})")]
     ProviderError {
         /// Not necessarily an HTTP status code, but a code that the provider uses to identify the error.
         ///
@@ -76,13 +78,18 @@ pub enum TaskError {
         /// Can be a provider name, or RPC etc.
         provider: String,
     },
+    /// Any other executor error that is not a provider error.
+    #[error("Executor error: {0}")]
+    ExecutorError(String),
     /// The task request had failed for some network reason.
+    #[error("Outbound request error: {code} - {message}")]
     OutboundRequestError {
         code: String,
         /// The error message returned by the network.
         message: String,
     },
-    /// An error that returned by executor.
+    /// Any other error
+    #[error("Other error: {0}")]
     Other(String),
 }
 

--- a/utils/src/payloads/tasks.rs
+++ b/utils/src/payloads/tasks.rs
@@ -63,7 +63,7 @@ pub enum TaskError {
     #[error("Parse error: {0}")]
     ParseError(String),
     /// An error returned from the model provider.
-    #[error("Provider error: {code} - {message} (source: {provider})")]
+    #[error("{provider} error ({code}): {message}")]
     ProviderError {
         /// Not necessarily an HTTP status code, but a code that the provider uses to identify the error.
         ///
@@ -78,6 +78,10 @@ pub enum TaskError {
         /// Can be a provider name, or RPC etc.
         provider: String,
     },
+    /// A network-related error from the client.
+    #[error("HTTP error: {0}")]
+    /// This is a generic HTTP error, not necessarily related to the provider.
+    HttpError(String),
     /// Any other executor error that is not a provider error.
     #[error("Executor error: {0}")]
     ExecutorError(String),


### PR DESCRIPTION
- `TaskWorkerMetadata` now has `model: Model` instead of `model: String`, allowing to reach provider name from it
- `TaskResponsePayload` now has `error: Option<TaskError>` field, instead of `error: Option<String>`
- A utility to convert a `PromptError` (from `rig`) to `TaskError` has been added
- Better error classes are used for other errors (e.g. parse error)
- Added Ollama error parsing logic as well, as they are not reported by some error code
- Added `with_push_listen_addr_updates(true)` to identify config
- Added performance reports for the service checks at the start, they are added to `Specs` now
- Bumps version to 0.6.0